### PR TITLE
Implements #4 — Add Companies and Shows with multi-company events

### DIFF
--- a/backend/functions/admin/__tests__/seedAndClear.test.ts
+++ b/backend/functions/admin/__tests__/seedAndClear.test.ts
@@ -22,6 +22,7 @@ vi.mock('../../../lib/dynamodb', () => ({
     TOURNAMENTS: 'Tournaments', EVENTS: 'Events', CONTENDER_RANKINGS: 'ContenderRankings',
     RANKING_HISTORY: 'RankingHistory', MATCH_TYPES: 'MatchTypes',
     STIPULATIONS: 'Stipulations', SEASON_AWARDS: 'SeasonAwards',
+    COMPANIES: 'Companies', SHOWS: 'Shows',
   },
 }));
 
@@ -88,6 +89,8 @@ describe('seedData', () => {
     expect(body.message).toBe('Sample data seeded successfully!');
 
     // Verify all expected categories have counts
+    expect(body.createdCounts.companies).toBe(3);
+    expect(body.createdCounts.shows).toBe(3);
     expect(body.createdCounts.divisions).toBe(3);
     expect(body.createdCounts.wrestlers).toBe(12);
     expect(body.createdCounts.seasons).toBe(1);
@@ -103,7 +106,7 @@ describe('seedData', () => {
     expect(body.createdCounts.matchTypes).toBe(6);
 
     // Verify put was called many times for all entity inserts
-    expect(mockPut.mock.calls.length).toBeGreaterThan(60);
+    expect(mockPut.mock.calls.length).toBeGreaterThan(66);
   });
 
   it('returns 500 when DynamoDB throws during seeding', async () => {
@@ -200,11 +203,11 @@ describe('clearAll', () => {
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
     expect(body.message).toBe('All data cleared successfully');
-    expect(mockDelete).toHaveBeenCalledTimes(22); // 11 tables * 2 items
+    expect(mockDelete).toHaveBeenCalledTimes(26); // 13 tables * 2 items
 
     const labels = ['wrestlers', 'matches', 'championships', 'championshipHistory',
       'tournaments', 'seasons', 'seasonStandings', 'divisions', 'events',
-      'contenderRankings', 'rankingHistory'];
+      'contenderRankings', 'rankingHistory', 'companies', 'shows'];
     for (const label of labels) {
       expect(body.deletedCounts[label]).toBe(2);
     }
@@ -279,7 +282,7 @@ describe('clearAll', () => {
     await clearAll(event, ctx, cb);
 
     const scanCalls = mockScanAll.mock.calls;
-    expect(scanCalls.length).toBe(11);
+    expect(scanCalls.length).toBe(13);
     for (const call of scanCalls) {
       expect(call[0].ExpressionAttributeNames).toHaveProperty('#pk');
       expect(call[0].ProjectionExpression).toContain('#pk');

--- a/backend/functions/admin/clearAll.ts
+++ b/backend/functions/admin/clearAll.ts
@@ -113,6 +113,12 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     // Delete all ranking history
     await clearTable('rankingHistory', TableNames.RANKING_HISTORY, 'wrestlerId', 'weekKey');
 
+    // Delete all companies
+    await clearTable('companies', TableNames.COMPANIES, 'companyId');
+
+    // Delete all shows
+    await clearTable('shows', TableNames.SHOWS, 'showId');
+
     const response: Record<string, unknown> = {
       message: totalErrors > 0
         ? `Data cleared with ${totalErrors} individual delete error(s)`

--- a/backend/functions/admin/dataTransferConfig.ts
+++ b/backend/functions/admin/dataTransferConfig.ts
@@ -15,7 +15,9 @@ export type ExportDatasetKey =
   | 'siteConfig'
   | 'stipulations'
   | 'matchTypes'
-  | 'seasonAwards';
+  | 'seasonAwards'
+  | 'companies'
+  | 'shows';
 
 export interface ExportTableConfig {
   key: ExportDatasetKey;
@@ -52,6 +54,8 @@ export const EXPORT_TABLES: readonly ExportTableConfig[] = [
   { key: 'stipulations', tableName: TableNames.STIPULATIONS, partitionKey: 'stipulationId' },
   { key: 'matchTypes', tableName: TableNames.MATCH_TYPES, partitionKey: 'matchTypeId' },
   { key: 'seasonAwards', tableName: TableNames.SEASON_AWARDS, partitionKey: 'seasonId', sortKey: 'awardId' },
+  { key: 'companies', tableName: TableNames.COMPANIES, partitionKey: 'companyId' },
+  { key: 'shows', tableName: TableNames.SHOWS, partitionKey: 'showId' },
 ] as const;
 
 export type ExportData = Record<ExportDatasetKey, Record<string, unknown>[]>;

--- a/backend/functions/admin/seedData.ts
+++ b/backend/functions/admin/seedData.ts
@@ -335,6 +335,71 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
     const createdCounts: Record<string, number> = {};
     const now = new Date().toISOString();
 
+    // ── Companies ─────────────────────────────────────────────
+    console.log('Creating companies...');
+    const companies = [
+      {
+        companyId: 'comp-wwf',
+        name: 'World Wrestling Federation',
+        abbreviation: 'WWF',
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        companyId: 'comp-wcw',
+        name: 'World Championship Wrestling',
+        abbreviation: 'WCW',
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        companyId: 'comp-ecw',
+        name: 'Extreme Championship Wrestling',
+        abbreviation: 'ECW',
+        createdAt: now,
+        updatedAt: now,
+      },
+    ];
+
+    for (const company of companies) {
+      await dynamoDb.put({ TableName: TableNames.COMPANIES, Item: company });
+    }
+    createdCounts.companies = companies.length;
+
+    // ── Shows ────────────────────────────────────────────────
+    console.log('Creating shows...');
+    const shows = [
+      {
+        showId: 'show-raw',
+        name: 'Monday Night Raw',
+        companyId: 'comp-wwf',
+        schedule: 'weekly',
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        showId: 'show-nitro',
+        name: 'Monday Nitro',
+        companyId: 'comp-wcw',
+        schedule: 'weekly',
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        showId: 'show-ecw-tv',
+        name: 'ECW Hardcore TV',
+        companyId: 'comp-ecw',
+        schedule: 'weekly',
+        createdAt: now,
+        updatedAt: now,
+      },
+    ];
+
+    for (const show of shows) {
+      await dynamoDb.put({ TableName: TableNames.SHOWS, Item: show });
+    }
+    createdCounts.shows = shows.length;
+
     // ── Divisions ──────────────────────────────────────────────
     console.log('Creating divisions...');
     const divisions = [
@@ -375,6 +440,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
       losses: Math.floor(Math.random() * 12) + 2,
       draws: Math.floor(Math.random() * 3),
       divisionId: divisions[index % divisions.length].divisionId,
+      companyId: companies[index % companies.length].companyId,
       createdAt: now,
       updatedAt: now,
     }));
@@ -424,6 +490,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
         type: 'singles',
         currentChampion: seedWrestlers[0].wrestlerId,
         divisionId: divisions[0].divisionId,
+        companyId: 'comp-wwf',
         isActive: true,
         createdAt: now,
         updatedAt: now,
@@ -434,6 +501,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
         name: 'Intercontinental Championship',
         type: 'singles',
         currentChampion: seedWrestlers[1].wrestlerId,
+        companyId: 'comp-wwf',
         isActive: true,
         createdAt: now,
         updatedAt: now,
@@ -444,6 +512,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
         name: 'Tag Team Championship',
         type: 'tag',
         currentChampion: [seedWrestlers[2].wrestlerId, seedWrestlers[3].wrestlerId],
+        companyId: 'comp-wcw',
         isActive: true,
         createdAt: now,
         updatedAt: now,
@@ -455,6 +524,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
         type: 'singles',
         currentChampion: seedWrestlers[4].wrestlerId,
         divisionId: divisions[1].divisionId,
+        companyId: 'comp-ecw',
         isActive: true,
         createdAt: now,
         updatedAt: now,

--- a/backend/functions/championships/__tests__/championships.test.ts
+++ b/backend/functions/championships/__tests__/championships.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../../lib/dynamodb', () => ({
     get: mockGet, put: mockPut, scan: mockScan, query: mockQuery,
     update: mockUpdate, delete: mockDelete, transactWrite: mockTransactWrite,
   },
-  TableNames: { CHAMPIONSHIPS: 'Championships', CHAMPIONSHIP_HISTORY: 'ChampionshipHistory' },
+  TableNames: { CHAMPIONSHIPS: 'Championships', CHAMPIONSHIP_HISTORY: 'ChampionshipHistory', COMPANIES: 'Companies' },
 }));
 vi.mock('uuid', () => ({ v4: () => 'test-uuid-1234' }));
 

--- a/backend/functions/championships/createChampionship.ts
+++ b/backend/functions/championships/createChampionship.ts
@@ -1,19 +1,28 @@
-import { TableNames } from '../../lib/dynamodb';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
 import { handlerFactory } from '../../lib/handlers';
-import { badRequest } from '../../lib/response';
+import { badRequest, notFound } from '../../lib/response';
 
 export const handler = handlerFactory({
   tableName: TableNames.CHAMPIONSHIPS,
   idField: 'championshipId',
   entityName: 'championship',
   requiredFields: ['name', 'type'],
-  optionalFields: ['currentChampion', 'divisionId', 'imageUrl'],
+  optionalFields: ['currentChampion', 'divisionId', 'imageUrl', 'companyId'],
   defaults: {
     isActive: true,
   },
   validate: async (body, _event) => {
     if (body.type !== 'singles' && body.type !== 'tag') {
       return badRequest('Type must be either "singles" or "tag"');
+    }
+    if (body.companyId) {
+      const companyResult = await dynamoDb.get({
+        TableName: TableNames.COMPANIES,
+        Key: { companyId: body.companyId },
+      });
+      if (!companyResult.Item) {
+        return notFound('Company not found');
+      }
     }
     return null;
   },

--- a/backend/functions/championships/updateChampionship.ts
+++ b/backend/functions/championships/updateChampionship.ts
@@ -31,6 +31,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       isActive: body.isActive,
       currentChampion: body.currentChampion,
       divisionId: body.divisionId,
+      companyId: body.companyId,
     });
 
     if (!updateExpr.hasChanges) {

--- a/backend/functions/companies/__tests__/companies.test.ts
+++ b/backend/functions/companies/__tests__/companies.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+// ─── Mocks ───────────────────────────────────────────────────────────
+
+const { mockGet, mockPut, mockScan, mockQuery, mockUpdate, mockDelete, mockScanAll, mockQueryAll } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPut: vi.fn(),
+  mockScan: vi.fn(),
+  mockQuery: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockDelete: vi.fn(),
+  mockScanAll: vi.fn(),
+  mockQueryAll: vi.fn(),
+}));
+
+vi.mock('../../../lib/dynamodb', () => ({
+  dynamoDb: {
+    get: mockGet,
+    put: mockPut,
+    scan: mockScan,
+    query: mockQuery,
+    update: mockUpdate,
+    delete: mockDelete,
+    scanAll: mockScanAll,
+    queryAll: mockQueryAll,
+  },
+  TableNames: {
+    COMPANIES: 'Companies',
+    WRESTLERS: 'Wrestlers',
+    SHOWS: 'Shows',
+  },
+}));
+
+vi.mock('uuid', () => ({
+  v4: () => 'test-uuid-1234',
+}));
+
+import { handler as getCompanies } from '../getCompanies';
+import { handler as getCompany } from '../getCompany';
+import { handler as createCompany } from '../createCompany';
+import { handler as updateCompany } from '../updateCompany';
+import { handler as deleteCompany } from '../deleteCompany';
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '/',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: { authorizer: {} } as APIGatewayProxyEvent['requestContext'],
+    ...overrides,
+  };
+}
+
+// ─── getCompanies ────────────────────────────────────────────────────
+
+describe('getCompanies', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns all companies sorted by name', async () => {
+    mockScan.mockResolvedValue({
+      Items: [
+        { companyId: 'c-2', name: 'WWE' },
+        { companyId: 'c-1', name: 'AEW' },
+      ],
+    });
+
+    const result = await getCompanies(makeEvent(), ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body).toHaveLength(2);
+    expect(body[0].name).toBe('AEW');
+    expect(body[1].name).toBe('WWE');
+    expect(mockScan).toHaveBeenCalledWith({ TableName: 'Companies' });
+  });
+
+  it('returns empty array when no companies exist', async () => {
+    mockScan.mockResolvedValue({ Items: undefined });
+
+    const result = await getCompanies(makeEvent(), ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body)).toEqual([]);
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    mockScan.mockRejectedValue(new Error('DynamoDB failure'));
+
+    const result = await getCompanies(makeEvent(), ctx, cb);
+
+    expect(result!.statusCode).toBe(500);
+    expect(JSON.parse(result!.body).message).toBe('Failed to fetch companies');
+  });
+});
+
+// ─── getCompany ──────────────────────────────────────────────────────
+
+describe('getCompany', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns a company by ID', async () => {
+    mockGet.mockResolvedValue({ Item: { companyId: 'c-1', name: 'WWE' } });
+
+    const result = await getCompany(
+      makeEvent({ pathParameters: { companyId: 'c-1' } }),
+      ctx,
+      cb
+    );
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body).name).toBe('WWE');
+  });
+
+  it('returns 400 when companyId is missing', async () => {
+    const result = await getCompany(makeEvent({ pathParameters: null }), ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('Company ID is required');
+  });
+
+  it('returns 404 when company not found', async () => {
+    mockGet.mockResolvedValue({ Item: undefined });
+
+    const result = await getCompany(
+      makeEvent({ pathParameters: { companyId: 'nonexistent' } }),
+      ctx,
+      cb
+    );
+
+    expect(result!.statusCode).toBe(404);
+    expect(JSON.parse(result!.body).message).toBe('Company not found');
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    mockGet.mockRejectedValue(new Error('DynamoDB failure'));
+
+    const result = await getCompany(
+      makeEvent({ pathParameters: { companyId: 'c-1' } }),
+      ctx,
+      cb
+    );
+
+    expect(result!.statusCode).toBe(500);
+    expect(JSON.parse(result!.body).message).toBe('Failed to fetch company');
+  });
+});
+
+// ─── createCompany ──────────────────────────────────────────────────
+
+describe('createCompany', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a company with name only and returns 201', async () => {
+    mockPut.mockResolvedValue({});
+    const event = makeEvent({ body: JSON.stringify({ name: 'WWE' }) });
+
+    const result = await createCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(201);
+    const body = JSON.parse(result!.body);
+    expect(body.companyId).toBe('test-uuid-1234');
+    expect(body.name).toBe('WWE');
+    expect(body.createdAt).toBeDefined();
+    expect(body.updatedAt).toBeDefined();
+    expect(mockPut).toHaveBeenCalledOnce();
+  });
+
+  it('creates a company with all optional fields', async () => {
+    mockPut.mockResolvedValue({});
+    const event = makeEvent({
+      body: JSON.stringify({
+        name: 'WWE',
+        abbreviation: 'WWE',
+        imageUrl: 'https://example.com/wwe.png',
+        description: 'World Wrestling Entertainment',
+      }),
+    });
+
+    const result = await createCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(201);
+    const body = JSON.parse(result!.body);
+    expect(body.name).toBe('WWE');
+    expect(body.abbreviation).toBe('WWE');
+    expect(body.imageUrl).toBe('https://example.com/wwe.png');
+    expect(body.description).toBe('World Wrestling Entertainment');
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const event = makeEvent({ body: JSON.stringify({ abbreviation: 'WWE' }) });
+
+    const result = await createCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('name is required');
+  });
+
+  it('returns 400 when body is null', async () => {
+    const result = await createCompany(makeEvent({ body: null }), ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('Request body is required');
+  });
+
+  it('returns 400 when body is malformed JSON', async () => {
+    const result = await createCompany(makeEvent({ body: '{bad json' }), ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('Invalid JSON in request body');
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    mockPut.mockRejectedValue(new Error('DynamoDB failure'));
+    const event = makeEvent({ body: JSON.stringify({ name: 'WWE' }) });
+
+    const result = await createCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(500);
+    expect(JSON.parse(result!.body).message).toBe('Failed to create company');
+  });
+});
+
+// ─── updateCompany ──────────────────────────────────────────────────
+
+describe('updateCompany', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('updates company name and returns updated record', async () => {
+    mockGet.mockResolvedValue({ Item: { companyId: 'c-1', name: 'WWE' } });
+    mockUpdate.mockResolvedValue({
+      Attributes: { companyId: 'c-1', name: 'WWE Updated', updatedAt: '2024-01-01' },
+    });
+
+    const event = makeEvent({
+      pathParameters: { companyId: 'c-1' },
+      body: JSON.stringify({ name: 'WWE Updated' }),
+    });
+
+    const result = await updateCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body).name).toBe('WWE Updated');
+    expect(mockUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('returns 400 when companyId is missing from path', async () => {
+    const event = makeEvent({
+      pathParameters: null,
+      body: JSON.stringify({ name: 'X' }),
+    });
+
+    const result = await updateCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('Company ID is required');
+  });
+
+  it('returns 404 when company does not exist', async () => {
+    mockGet.mockResolvedValue({ Item: undefined });
+
+    const event = makeEvent({
+      pathParameters: { companyId: 'nonexistent' },
+      body: JSON.stringify({ name: 'X' }),
+    });
+
+    const result = await updateCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(404);
+    expect(JSON.parse(result!.body).message).toBe('Company not found');
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    mockGet.mockResolvedValue({ Item: { companyId: 'c-1' } });
+    mockUpdate.mockRejectedValue(new Error('DynamoDB failure'));
+
+    const event = makeEvent({
+      pathParameters: { companyId: 'c-1' },
+      body: JSON.stringify({ name: 'X' }),
+    });
+
+    const result = await updateCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(500);
+    expect(JSON.parse(result!.body).message).toBe('Failed to update company');
+  });
+});
+
+// ─── deleteCompany ──────────────────────────────────────────────────
+
+describe('deleteCompany', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes company and returns 204', async () => {
+    mockGet.mockResolvedValue({ Item: { companyId: 'c-1', name: 'WWE' } });
+    mockScan.mockResolvedValue({ Items: [] });
+    mockQuery.mockResolvedValue({ Items: [] });
+    mockDelete.mockResolvedValue({});
+
+    const event = makeEvent({ pathParameters: { companyId: 'c-1' } });
+
+    const result = await deleteCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(204);
+    expect(mockDelete).toHaveBeenCalledWith({
+      TableName: 'Companies',
+      Key: { companyId: 'c-1' },
+    });
+  });
+
+  it('returns 400 when companyId is missing from path', async () => {
+    const result = await deleteCompany(makeEvent({ pathParameters: null }), ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('Company ID is required');
+  });
+
+  it('returns 404 when company does not exist', async () => {
+    mockGet.mockResolvedValue({ Item: undefined });
+
+    const event = makeEvent({ pathParameters: { companyId: 'nonexistent' } });
+
+    const result = await deleteCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(404);
+    expect(JSON.parse(result!.body).message).toBe('Company not found');
+  });
+
+  it('returns 409 when wrestlers are assigned to the company', async () => {
+    mockGet.mockResolvedValue({ Item: { companyId: 'c-1', name: 'WWE' } });
+    mockScan.mockResolvedValue({
+      Items: [
+        { wrestlerId: 'w1', name: 'John Cena', companyId: 'c-1' },
+      ],
+    });
+
+    const event = makeEvent({ pathParameters: { companyId: 'c-1' } });
+
+    const result = await deleteCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(409);
+    expect(JSON.parse(result!.body).message).toContain('1 wrestler(s)');
+    expect(JSON.parse(result!.body).message).toContain('Cannot delete company');
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when shows are assigned to the company', async () => {
+    mockGet.mockResolvedValue({ Item: { companyId: 'c-1', name: 'WWE' } });
+    mockScan.mockResolvedValue({ Items: [] });
+    mockQuery.mockResolvedValue({
+      Items: [
+        { showId: 's1', name: 'Raw', companyId: 'c-1' },
+        { showId: 's2', name: 'SmackDown', companyId: 'c-1' },
+      ],
+    });
+
+    const event = makeEvent({ pathParameters: { companyId: 'c-1' } });
+
+    const result = await deleteCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(409);
+    expect(JSON.parse(result!.body).message).toContain('2 show(s)');
+    expect(JSON.parse(result!.body).message).toContain('Cannot delete company');
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    mockGet.mockRejectedValue(new Error('DynamoDB failure'));
+
+    const event = makeEvent({ pathParameters: { companyId: 'c-1' } });
+
+    const result = await deleteCompany(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(500);
+    expect(JSON.parse(result!.body).message).toBe('Failed to delete company');
+  });
+});

--- a/backend/functions/companies/__tests__/handler.test.ts
+++ b/backend/functions/companies/__tests__/handler.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
+
+const mockGetCompanies = vi.fn();
+const mockGetCompany = vi.fn();
+const mockCreateCompany = vi.fn();
+const mockUpdateCompany = vi.fn();
+const mockDeleteCompany = vi.fn();
+
+vi.mock('../getCompanies', () => ({ handler: (...args: unknown[]) => mockGetCompanies(...args) }));
+vi.mock('../getCompany', () => ({ handler: (...args: unknown[]) => mockGetCompany(...args) }));
+vi.mock('../createCompany', () => ({ handler: (...args: unknown[]) => mockCreateCompany(...args) }));
+vi.mock('../updateCompany', () => ({ handler: (...args: unknown[]) => mockUpdateCompany(...args) }));
+vi.mock('../deleteCompany', () => ({ handler: (...args: unknown[]) => mockDeleteCompany(...args) }));
+
+import { handler } from '../handler';
+
+const ctx = {} as Context;
+const noopCb = () => {};
+
+function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+  return {
+    httpMethod: 'GET',
+    path: '/companies',
+    pathParameters: null,
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    requestContext: {} as APIGatewayProxyEvent['requestContext'],
+    resource: '/companies',
+    ...overrides,
+  };
+}
+
+describe('companies router handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCompanies.mockResolvedValue({ statusCode: 200, body: '[]' });
+    mockGetCompany.mockResolvedValue({ statusCode: 200, body: '{}' });
+    mockCreateCompany.mockResolvedValue({ statusCode: 201, body: '{}' });
+    mockUpdateCompany.mockResolvedValue({ statusCode: 200, body: '{}' });
+    mockDeleteCompany.mockResolvedValue({ statusCode: 204, body: '' });
+  });
+
+  it('GET /companies calls getCompanies', async () => {
+    const event = makeEvent({ httpMethod: 'GET', resource: '/companies' });
+    const result = await handler(event, ctx, noopCb);
+    expect(mockGetCompanies).toHaveBeenCalledWith(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(200);
+  });
+
+  it('POST /companies calls createCompany', async () => {
+    const event = makeEvent({ httpMethod: 'POST', resource: '/companies' });
+    const result = await handler(event, ctx, noopCb);
+    expect(mockCreateCompany).toHaveBeenCalledWith(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(201);
+  });
+
+  it('GET /companies/{companyId} calls getCompany', async () => {
+    const event = makeEvent({
+      httpMethod: 'GET',
+      resource: '/companies/{companyId}',
+      pathParameters: { companyId: 'c-1' },
+    });
+    const result = await handler(event, ctx, noopCb);
+    expect(mockGetCompany).toHaveBeenCalledWith(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(200);
+  });
+
+  it('PUT /companies/{companyId} calls updateCompany', async () => {
+    const event = makeEvent({
+      httpMethod: 'PUT',
+      resource: '/companies/{companyId}',
+      pathParameters: { companyId: 'c-1' },
+    });
+    const result = await handler(event, ctx, noopCb);
+    expect(mockUpdateCompany).toHaveBeenCalledWith(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(200);
+  });
+
+  it('DELETE /companies/{companyId} calls deleteCompany', async () => {
+    const event = makeEvent({
+      httpMethod: 'DELETE',
+      resource: '/companies/{companyId}',
+      pathParameters: { companyId: 'c-1' },
+    });
+    const result = await handler(event, ctx, noopCb);
+    expect(mockDeleteCompany).toHaveBeenCalledWith(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(204);
+  });
+
+  it('PATCH returns 405 Method Not Allowed', async () => {
+    const event = makeEvent({ httpMethod: 'PATCH' });
+    const result = await handler(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(405);
+  });
+});

--- a/backend/functions/companies/createCompany.ts
+++ b/backend/functions/companies/createCompany.ts
@@ -1,0 +1,10 @@
+import { TableNames } from '../../lib/dynamodb';
+import { handlerFactory } from '../../lib/handlers';
+
+export const handler = handlerFactory({
+  tableName: TableNames.COMPANIES,
+  idField: 'companyId',
+  entityName: 'company',
+  requiredFields: ['name'],
+  optionalFields: ['abbreviation', 'imageUrl', 'description'],
+});

--- a/backend/functions/companies/deleteCompany.ts
+++ b/backend/functions/companies/deleteCompany.ts
@@ -1,0 +1,66 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { getOrNotFound } from '../../lib/dynamodbUtils';
+import { noContent, badRequest, serverError, conflict } from '../../lib/response';
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const companyId = event.pathParameters?.companyId;
+
+    if (!companyId) {
+      return badRequest('Company ID is required');
+    }
+
+    const companyResult = await getOrNotFound(TableNames.COMPANIES, { companyId }, 'Company not found');
+    if ('notFoundResponse' in companyResult) {
+      return companyResult.notFoundResponse;
+    }
+
+    // Check if any wrestlers are assigned to this company
+    const wrestlersResult = await dynamoDb.scan({
+      TableName: TableNames.WRESTLERS,
+      FilterExpression: '#companyId = :companyId',
+      ExpressionAttributeNames: {
+        '#companyId': 'companyId',
+      },
+      ExpressionAttributeValues: {
+        ':companyId': companyId,
+      },
+    });
+
+    if (wrestlersResult.Items && wrestlersResult.Items.length > 0) {
+      return conflict(
+        `Cannot delete company. ${wrestlersResult.Items.length} wrestler(s) are still assigned to this company.`
+      );
+    }
+
+    // Check if any shows are assigned to this company
+    const showsResult = await dynamoDb.query({
+      TableName: TableNames.SHOWS,
+      IndexName: 'CompanyShowsIndex',
+      KeyConditionExpression: '#companyId = :companyId',
+      ExpressionAttributeNames: {
+        '#companyId': 'companyId',
+      },
+      ExpressionAttributeValues: {
+        ':companyId': companyId,
+      },
+    });
+
+    if (showsResult.Items && showsResult.Items.length > 0) {
+      return conflict(
+        `Cannot delete company. ${showsResult.Items.length} show(s) are still assigned to this company.`
+      );
+    }
+
+    await dynamoDb.delete({
+      TableName: TableNames.COMPANIES,
+      Key: { companyId },
+    });
+
+    return noContent();
+  } catch (err) {
+    console.error('Error deleting company:', err);
+    return serverError('Failed to delete company');
+  }
+};

--- a/backend/functions/companies/getCompanies.ts
+++ b/backend/functions/companies/getCompanies.ts
@@ -1,0 +1,25 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { success, serverError } from '../../lib/response';
+
+export const handler: APIGatewayProxyHandler = async () => {
+  try {
+    const result = await dynamoDb.scan({
+      TableName: TableNames.COMPANIES,
+    });
+
+    const companies = (result.Items || []) as Record<string, unknown>[];
+
+    // Sort by name ascending
+    companies.sort((a, b) => {
+      const nameA = (a.name as string) || '';
+      const nameB = (b.name as string) || '';
+      return nameA.localeCompare(nameB);
+    });
+
+    return success(companies);
+  } catch (err) {
+    console.error('Error fetching companies:', err);
+    return serverError('Failed to fetch companies');
+  }
+};

--- a/backend/functions/companies/getCompany.ts
+++ b/backend/functions/companies/getCompany.ts
@@ -1,0 +1,27 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { success, badRequest, notFound, serverError } from '../../lib/response';
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const companyId = event.pathParameters?.companyId;
+
+    if (!companyId) {
+      return badRequest('Company ID is required');
+    }
+
+    const result = await dynamoDb.get({
+      TableName: TableNames.COMPANIES,
+      Key: { companyId },
+    });
+
+    if (!result.Item) {
+      return notFound('Company not found');
+    }
+
+    return success(result.Item);
+  } catch (err) {
+    console.error('Error fetching company:', err);
+    return serverError('Failed to fetch company');
+  }
+};

--- a/backend/functions/companies/handler.ts
+++ b/backend/functions/companies/handler.ts
@@ -1,0 +1,35 @@
+import { handler as getCompaniesHandler } from './getCompanies';
+import { handler as getCompanyHandler } from './getCompany';
+import { handler as createCompanyHandler } from './createCompany';
+import { handler as updateCompanyHandler } from './updateCompany';
+import { handler as deleteCompanyHandler } from './deleteCompany';
+import { createRouter, RouteConfig } from '../../lib/router';
+
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/companies',
+    method: 'GET',
+    handler: getCompaniesHandler,
+  },
+  {
+    resource: '/companies',
+    method: 'POST',
+    handler: createCompanyHandler,
+  },
+  {
+    resource: '/companies/{companyId}',
+    method: 'GET',
+    handler: getCompanyHandler,
+  },
+  {
+    resource: '/companies/{companyId}',
+    method: 'PUT',
+    handler: updateCompanyHandler,
+  },
+  {
+    resource: '/companies/{companyId}',
+    method: 'DELETE',
+    handler: deleteCompanyHandler,
+  },
+];
+export const handler = createRouter(routes);

--- a/backend/functions/companies/updateCompany.ts
+++ b/backend/functions/companies/updateCompany.ts
@@ -1,0 +1,55 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { buildUpdateExpression, getOrNotFound } from '../../lib/dynamodbUtils';
+import { success, badRequest, serverError } from '../../lib/response';
+import { parseBody } from '../../lib/parseBody';
+
+interface UpdateCompanyBody {
+  name?: string;
+  abbreviation?: string;
+  imageUrl?: string;
+  description?: string;
+}
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const companyId = event.pathParameters?.companyId;
+
+    if (!companyId) {
+      return badRequest('Company ID is required');
+    }
+
+    const { data: body, error: parseError } = parseBody<UpdateCompanyBody>(event);
+    if (parseError) return parseError;
+
+    const companyResult = await getOrNotFound(TableNames.COMPANIES, { companyId }, 'Company not found');
+    if ('notFoundResponse' in companyResult) {
+      return companyResult.notFoundResponse;
+    }
+
+    const updateExpr = buildUpdateExpression({
+      name: body.name,
+      abbreviation: body.abbreviation,
+      imageUrl: body.imageUrl,
+      description: body.description,
+    });
+
+    if (!updateExpr.hasChanges) {
+      return badRequest('No valid fields to update');
+    }
+
+    const result = await dynamoDb.update({
+      TableName: TableNames.COMPANIES,
+      Key: { companyId },
+      UpdateExpression: updateExpr.UpdateExpression,
+      ExpressionAttributeNames: updateExpr.ExpressionAttributeNames,
+      ExpressionAttributeValues: updateExpr.ExpressionAttributeValues,
+      ReturnValues: 'ALL_NEW',
+    });
+
+    return success(result.Attributes);
+  } catch (err) {
+    console.error('Error updating company:', err);
+    return serverError('Failed to update company');
+  }
+};

--- a/backend/functions/divisions/createDivision.ts
+++ b/backend/functions/divisions/createDivision.ts
@@ -6,6 +6,6 @@ export const handler = handlerFactory({
   idField: 'divisionId',
   entityName: 'division',
   requiredFields: ['name'],
-  optionalFields: ['description'],
+  optionalFields: ['description', 'companyId'],
 });
 

--- a/backend/functions/divisions/updateDivision.ts
+++ b/backend/functions/divisions/updateDivision.ts
@@ -7,6 +7,7 @@ import { parseBody } from '../../lib/parseBody';
 interface UpdateDivisionBody {
   name?: string;
   description?: string;
+  companyId?: string;
 }
 
 export const handler: APIGatewayProxyHandler = async (event) => {
@@ -28,6 +29,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const updateExpr = buildUpdateExpression({
       name: body.name,
       description: body.description,
+      companyId: body.companyId,
     });
 
     if (!updateExpr.hasChanges) {

--- a/backend/functions/events/__tests__/createEvent.test.ts
+++ b/backend/functions/events/__tests__/createEvent.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../../lib/dynamodb', () => ({
     get: vi.fn(), put: mockPut, scan: vi.fn(), query: vi.fn(),
     update: vi.fn(), delete: vi.fn(), scanAll: vi.fn(), queryAll: vi.fn(),
   },
-  TableNames: { EVENTS: 'Events' },
+  TableNames: { EVENTS: 'Events', COMPANIES: 'Companies' },
 }));
 
 vi.mock('uuid', () => ({ v4: () => 'test-event-uuid' }));

--- a/backend/functions/events/__tests__/getEvent.test.ts
+++ b/backend/functions/events/__tests__/getEvent.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../../lib/dynamodb', () => ({
   TableNames: {
     EVENTS: 'Events', MATCHES: 'Matches',
     WRESTLERS: 'Wrestlers', CHAMPIONSHIPS: 'Championships',
+    COMPANIES: 'Companies',
   },
 }));
 

--- a/backend/functions/events/__tests__/updateEvent.test.ts
+++ b/backend/functions/events/__tests__/updateEvent.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../../lib/dynamodb', () => ({
     get: mockGet, put: vi.fn(), scan: vi.fn(), query: vi.fn(),
     update: mockUpdate, delete: vi.fn(), scanAll: vi.fn(), queryAll: vi.fn(),
   },
-  TableNames: { EVENTS: 'Events' },
+  TableNames: { EVENTS: 'Events', COMPANIES: 'Companies' },
 }));
 
 import { handler as updateEvent } from '../updateEvent';

--- a/backend/functions/events/createEvent.ts
+++ b/backend/functions/events/createEvent.ts
@@ -1,17 +1,32 @@
-import { TableNames } from '../../lib/dynamodb';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
 import { handlerFactory } from '../../lib/handlers';
-import { badRequest } from '../../lib/response';
+import { badRequest, notFound } from '../../lib/response';
 
 export const handler = handlerFactory({
   tableName: TableNames.EVENTS,
   idField: 'eventId',
   entityName: 'event',
   requiredFields: ['name', 'eventType', 'date'],
+  optionalFields: ['companyIds', 'showId'],
   nullableFields: ['venue', 'description', 'imageUrl', 'themeColor', 'seasonId', 'fantasyBudget', 'fantasyPicksPerDivision'],
   defaults: { status: 'upcoming', matchCards: [], attendance: null, rating: null, fantasyEnabled: true },
   validate: async (body, _event) => {
     if (body.eventType !== 'ppv' && body.eventType !== 'weekly' && body.eventType !== 'special' && body.eventType !== 'house') {
       return badRequest('eventType must be one of ppv, weekly, special, or house');
+    }
+    if (body.companyIds) {
+      if (!Array.isArray(body.companyIds)) {
+        return badRequest('companyIds must be an array of company IDs');
+      }
+      for (const companyId of body.companyIds as string[]) {
+        const companyResult = await dynamoDb.get({
+          TableName: TableNames.COMPANIES,
+          Key: { companyId },
+        });
+        if (!companyResult.Item) {
+          return notFound(`Company ${companyId} not found`);
+        }
+      }
     }
     return null;
   },

--- a/backend/functions/events/getEvent.ts
+++ b/backend/functions/events/getEvent.ts
@@ -118,9 +118,25 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       })
     );
 
+    // Enrich with company names if companyIds are present
+    let companyNames: string[] | undefined;
+    if (eventItem.companyIds && Array.isArray(eventItem.companyIds) && (eventItem.companyIds as string[]).length > 0) {
+      companyNames = await Promise.all(
+        (eventItem.companyIds as string[]).map(async (companyId: string) => {
+          const companyResult = await dynamoDb.get({
+            TableName: TableNames.COMPANIES,
+            Key: { companyId },
+          });
+          const company = companyResult.Item as Record<string, unknown> | undefined;
+          return (company?.name as string) || 'Unknown Company';
+        })
+      );
+    }
+
     return success({
       ...eventItem,
       enrichedMatches,
+      ...(companyNames && { companyNames }),
     });
   } catch (err) {
     console.error('Error fetching event:', err);

--- a/backend/functions/events/updateEvent.ts
+++ b/backend/functions/events/updateEvent.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { dynamoDb, TableNames } from '../../lib/dynamodb';
 import { buildUpdateExpression, getOrNotFound } from '../../lib/dynamodbUtils';
-import { success, badRequest, serverError } from '../../lib/response';
+import { success, badRequest, notFound, serverError } from '../../lib/response';
 import { parseBody } from '../../lib/parseBody';
 
 interface MatchCardEntry {
@@ -28,6 +28,8 @@ interface UpdateEventBody {
   fantasyLocked?: boolean;
   fantasyBudget?: number;
   fantasyPicksPerDivision?: number;
+  companyIds?: string[];
+  showId?: string;
 }
 
 const VALID_EVENT_TYPES = ['ppv', 'weekly', 'special', 'house'];
@@ -59,6 +61,22 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return badRequest('status must be one of: upcoming, in-progress, completed, cancelled');
     }
 
+    // Validate companyIds if provided
+    if (body.companyIds !== undefined) {
+      if (!Array.isArray(body.companyIds)) {
+        return badRequest('companyIds must be an array of company IDs');
+      }
+      for (const companyId of body.companyIds) {
+        const companyResult = await dynamoDb.get({
+          TableName: TableNames.COMPANIES,
+          Key: { companyId },
+        });
+        if (!companyResult.Item) {
+          return notFound(`Company ${companyId} not found`);
+        }
+      }
+    }
+
     const updateExpr = buildUpdateExpression({
       name: body.name,
       eventType: body.eventType,
@@ -76,6 +94,8 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       fantasyLocked: body.fantasyLocked,
       fantasyBudget: body.fantasyBudget,
       fantasyPicksPerDivision: body.fantasyPicksPerDivision,
+      companyIds: body.companyIds,
+      showId: body.showId,
     });
 
     if (!updateExpr.hasChanges) {

--- a/backend/functions/matches/__tests__/scheduleMatch.test.ts
+++ b/backend/functions/matches/__tests__/scheduleMatch.test.ts
@@ -202,11 +202,12 @@ describe('scheduleMatch', () => {
   });
 
   it('resolves date from event when date not provided', async () => {
-    // Call order: 1) event for date resolution, 2) wrestler p1, 3) wrestler p2, 4) event for matchCards
+    // Call order: 1) event for date resolution, 2) wrestler p1, 3) wrestler p2, 4) event for roster validation, 5) event for matchCards
     mockGet
       .mockResolvedValueOnce({ Item: { eventId: 'e1', date: '2024-07-04T00:00:00Z' } })
       .mockResolvedValueOnce({ Item: { wrestlerId: 'p1' } })
       .mockResolvedValueOnce({ Item: { wrestlerId: 'p2' } })
+      .mockResolvedValueOnce({ Item: { eventId: 'e1' } }) // roster validation
       .mockResolvedValueOnce({ Item: { eventId: 'e1', matchCards: [] } });
     mockPut.mockResolvedValue({});
     mockUpdate.mockResolvedValue({});
@@ -221,6 +222,7 @@ describe('scheduleMatch', () => {
     mockGet
       .mockResolvedValueOnce({ Item: { wrestlerId: 'p1' } })
       .mockResolvedValueOnce({ Item: { wrestlerId: 'p2' } })
+      .mockResolvedValueOnce({ Item: { eventId: 'e1' } }) // roster validation fetch
       .mockResolvedValueOnce({ Item: { eventId: 'e1', matchCards: [{ matchId: 'x' }] } });
     mockPut.mockResolvedValue({});
     mockUpdate.mockResolvedValue({});

--- a/backend/functions/matches/scheduleMatch.ts
+++ b/backend/functions/matches/scheduleMatch.ts
@@ -67,6 +67,27 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return notFound(`Wrestlers not found: ${missingWrestlers.join(', ')}`);
     }
 
+    // Validate participants belong to hosting companies if event has companyIds
+    if (body.eventId) {
+      const eventForCompanies = await dynamoDb.get({
+        TableName: TableNames.EVENTS,
+        Key: { eventId: body.eventId },
+      });
+
+      if (eventForCompanies.Item) {
+        const companyIds = (eventForCompanies.Item as Record<string, unknown>).companyIds as string[] | undefined;
+        if (companyIds && companyIds.length > 0) {
+          for (const result of wrestlerResults) {
+            const wrestlerCompanyId = (result.wrestler as Record<string, unknown>)?.companyId as string | undefined;
+            if (wrestlerCompanyId && !companyIds.includes(wrestlerCompanyId)) {
+              const wrestlerName = (result.wrestler as Record<string, unknown>)?.name as string || result.wrestlerId;
+              return badRequest(`Wrestler ${wrestlerName} is not on a hosting company's roster`);
+            }
+          }
+        }
+      }
+    }
+
     // Validate championship exists if provided
     if (body.championshipId) {
       const championship = await dynamoDb.get({

--- a/backend/functions/shows/__tests__/handler.test.ts
+++ b/backend/functions/shows/__tests__/handler.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
+
+const mockGetShows = vi.fn();
+const mockGetShow = vi.fn();
+const mockCreateShow = vi.fn();
+const mockUpdateShow = vi.fn();
+const mockDeleteShow = vi.fn();
+
+vi.mock('../getShows', () => ({ handler: (...args: unknown[]) => mockGetShows(...args) }));
+vi.mock('../getShow', () => ({ handler: (...args: unknown[]) => mockGetShow(...args) }));
+vi.mock('../createShow', () => ({ handler: (...args: unknown[]) => mockCreateShow(...args) }));
+vi.mock('../updateShow', () => ({ handler: (...args: unknown[]) => mockUpdateShow(...args) }));
+vi.mock('../deleteShow', () => ({ handler: (...args: unknown[]) => mockDeleteShow(...args) }));
+
+import { handler } from '../handler';
+
+const ctx = {} as Context;
+const noopCb = () => {};
+
+function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+  return {
+    httpMethod: 'GET',
+    path: '/shows',
+    pathParameters: null,
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    requestContext: {} as APIGatewayProxyEvent['requestContext'],
+    resource: '/shows',
+    ...overrides,
+  };
+}
+
+describe('shows router handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetShows.mockResolvedValue({ statusCode: 200, body: '[]' });
+    mockGetShow.mockResolvedValue({ statusCode: 200, body: '{}' });
+    mockCreateShow.mockResolvedValue({ statusCode: 201, body: '{}' });
+    mockUpdateShow.mockResolvedValue({ statusCode: 200, body: '{}' });
+    mockDeleteShow.mockResolvedValue({ statusCode: 204, body: '' });
+  });
+
+  it('GET /shows calls getShows', async () => {
+    const event = makeEvent({ httpMethod: 'GET', resource: '/shows' });
+    const result = await handler(event, ctx, noopCb);
+    expect(mockGetShows).toHaveBeenCalledWith(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(200);
+  });
+
+  it('POST /shows calls createShow', async () => {
+    const event = makeEvent({ httpMethod: 'POST', resource: '/shows' });
+    const result = await handler(event, ctx, noopCb);
+    expect(mockCreateShow).toHaveBeenCalledWith(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(201);
+  });
+
+  it('GET /shows/{showId} calls getShow', async () => {
+    const event = makeEvent({
+      httpMethod: 'GET',
+      resource: '/shows/{showId}',
+      pathParameters: { showId: 's-1' },
+    });
+    const result = await handler(event, ctx, noopCb);
+    expect(mockGetShow).toHaveBeenCalledWith(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(200);
+  });
+
+  it('PUT /shows/{showId} calls updateShow', async () => {
+    const event = makeEvent({
+      httpMethod: 'PUT',
+      resource: '/shows/{showId}',
+      pathParameters: { showId: 's-1' },
+    });
+    const result = await handler(event, ctx, noopCb);
+    expect(mockUpdateShow).toHaveBeenCalledWith(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(200);
+  });
+
+  it('DELETE /shows/{showId} calls deleteShow', async () => {
+    const event = makeEvent({
+      httpMethod: 'DELETE',
+      resource: '/shows/{showId}',
+      pathParameters: { showId: 's-1' },
+    });
+    const result = await handler(event, ctx, noopCb);
+    expect(mockDeleteShow).toHaveBeenCalledWith(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(204);
+  });
+
+  it('PATCH returns 405 Method Not Allowed', async () => {
+    const event = makeEvent({ httpMethod: 'PATCH' });
+    const result = await handler(event, ctx, noopCb);
+    expect(result!.statusCode).toBe(405);
+  });
+});

--- a/backend/functions/shows/__tests__/shows.test.ts
+++ b/backend/functions/shows/__tests__/shows.test.ts
@@ -1,0 +1,451 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+// ─── Mocks ───────────────────────────────────────────────────────────
+
+const { mockGet, mockPut, mockScan, mockQuery, mockUpdate, mockDelete, mockScanAll, mockQueryAll } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPut: vi.fn(),
+  mockScan: vi.fn(),
+  mockQuery: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockDelete: vi.fn(),
+  mockScanAll: vi.fn(),
+  mockQueryAll: vi.fn(),
+}));
+
+vi.mock('../../../lib/dynamodb', () => ({
+  dynamoDb: {
+    get: mockGet,
+    put: mockPut,
+    scan: mockScan,
+    query: mockQuery,
+    update: mockUpdate,
+    delete: mockDelete,
+    scanAll: mockScanAll,
+    queryAll: mockQueryAll,
+  },
+  TableNames: {
+    SHOWS: 'Shows',
+    COMPANIES: 'Companies',
+    EVENTS: 'Events',
+  },
+}));
+
+vi.mock('uuid', () => ({
+  v4: () => 'test-uuid-5678',
+}));
+
+import { handler as getShows } from '../getShows';
+import { handler as getShow } from '../getShow';
+import { handler as createShow } from '../createShow';
+import { handler as updateShow } from '../updateShow';
+import { handler as deleteShow } from '../deleteShow';
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '/',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: { authorizer: {} } as APIGatewayProxyEvent['requestContext'],
+    ...overrides,
+  };
+}
+
+// ─── getShows ────────────────────────────────────────────────────────
+
+describe('getShows', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns all shows sorted by name when no companyId filter', async () => {
+    mockScan.mockResolvedValue({
+      Items: [
+        { showId: 's-2', name: 'SmackDown', companyId: 'c-1' },
+        { showId: 's-1', name: 'Raw', companyId: 'c-1' },
+      ],
+    });
+
+    const result = await getShows(makeEvent(), ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body).toHaveLength(2);
+    expect(body[0].name).toBe('Raw');
+    expect(body[1].name).toBe('SmackDown');
+    expect(mockScan).toHaveBeenCalledWith({ TableName: 'Shows' });
+  });
+
+  it('queries by companyId when filter provided', async () => {
+    mockQuery.mockResolvedValue({
+      Items: [
+        { showId: 's-1', name: 'Raw', companyId: 'c-1' },
+      ],
+    });
+
+    const result = await getShows(
+      makeEvent({ queryStringParameters: { companyId: 'c-1' } }),
+      ctx,
+      cb
+    );
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body).toHaveLength(1);
+    expect(body[0].name).toBe('Raw');
+    expect(mockQuery).toHaveBeenCalledWith({
+      TableName: 'Shows',
+      IndexName: 'CompanyShowsIndex',
+      KeyConditionExpression: '#companyId = :companyId',
+      ExpressionAttributeNames: { '#companyId': 'companyId' },
+      ExpressionAttributeValues: { ':companyId': 'c-1' },
+    });
+  });
+
+  it('returns empty array when no shows exist', async () => {
+    mockScan.mockResolvedValue({ Items: undefined });
+
+    const result = await getShows(makeEvent(), ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body)).toEqual([]);
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    mockScan.mockRejectedValue(new Error('DynamoDB failure'));
+
+    const result = await getShows(makeEvent(), ctx, cb);
+
+    expect(result!.statusCode).toBe(500);
+    expect(JSON.parse(result!.body).message).toBe('Failed to fetch shows');
+  });
+});
+
+// ─── getShow ─────────────────────────────────────────────────────────
+
+describe('getShow', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns a show by ID', async () => {
+    mockGet.mockResolvedValue({ Item: { showId: 's-1', name: 'Raw', companyId: 'c-1' } });
+
+    const result = await getShow(
+      makeEvent({ pathParameters: { showId: 's-1' } }),
+      ctx,
+      cb
+    );
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body).name).toBe('Raw');
+  });
+
+  it('returns 400 when showId is missing', async () => {
+    const result = await getShow(makeEvent({ pathParameters: null }), ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('Show ID is required');
+  });
+
+  it('returns 404 when show not found', async () => {
+    mockGet.mockResolvedValue({ Item: undefined });
+
+    const result = await getShow(
+      makeEvent({ pathParameters: { showId: 'nonexistent' } }),
+      ctx,
+      cb
+    );
+
+    expect(result!.statusCode).toBe(404);
+    expect(JSON.parse(result!.body).message).toBe('Show not found');
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    mockGet.mockRejectedValue(new Error('DynamoDB failure'));
+
+    const result = await getShow(
+      makeEvent({ pathParameters: { showId: 's-1' } }),
+      ctx,
+      cb
+    );
+
+    expect(result!.statusCode).toBe(500);
+    expect(JSON.parse(result!.body).message).toBe('Failed to fetch show');
+  });
+});
+
+// ─── createShow ─────────────────────────────────────────────────────
+
+describe('createShow', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a show and returns 201', async () => {
+    mockGet.mockResolvedValue({ Item: { companyId: 'c-1', name: 'WWE' } });
+    mockPut.mockResolvedValue({});
+
+    const event = makeEvent({
+      body: JSON.stringify({ name: 'Raw', companyId: 'c-1' }),
+    });
+
+    const result = await createShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(201);
+    const body = JSON.parse(result!.body);
+    expect(body.showId).toBe('test-uuid-5678');
+    expect(body.name).toBe('Raw');
+    expect(body.companyId).toBe('c-1');
+    expect(body.createdAt).toBeDefined();
+    expect(mockPut).toHaveBeenCalledOnce();
+  });
+
+  it('creates a show with optional fields', async () => {
+    mockGet.mockResolvedValue({ Item: { companyId: 'c-1', name: 'WWE' } });
+    mockPut.mockResolvedValue({});
+
+    const event = makeEvent({
+      body: JSON.stringify({
+        name: 'Raw',
+        companyId: 'c-1',
+        description: 'Monday Night Raw',
+        schedule: 'weekly',
+      }),
+    });
+
+    const result = await createShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(201);
+    const body = JSON.parse(result!.body);
+    expect(body.description).toBe('Monday Night Raw');
+    expect(body.schedule).toBe('weekly');
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const event = makeEvent({ body: JSON.stringify({ companyId: 'c-1' }) });
+
+    const result = await createShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('name is required');
+  });
+
+  it('returns 400 when companyId is missing', async () => {
+    const event = makeEvent({ body: JSON.stringify({ name: 'Raw' }) });
+
+    const result = await createShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('companyId is required');
+  });
+
+  it('returns 404 when company does not exist', async () => {
+    mockGet.mockResolvedValue({ Item: undefined });
+
+    const event = makeEvent({
+      body: JSON.stringify({ name: 'Raw', companyId: 'nonexistent' }),
+    });
+
+    const result = await createShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(404);
+    expect(JSON.parse(result!.body).message).toContain('Company');
+    expect(JSON.parse(result!.body).message).toContain('not found');
+  });
+
+  it('returns 400 when body is null', async () => {
+    const result = await createShow(makeEvent({ body: null }), ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('Request body is required');
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    mockGet.mockResolvedValue({ Item: { companyId: 'c-1', name: 'WWE' } });
+    mockPut.mockRejectedValue(new Error('DynamoDB failure'));
+
+    const event = makeEvent({
+      body: JSON.stringify({ name: 'Raw', companyId: 'c-1' }),
+    });
+
+    const result = await createShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(500);
+    expect(JSON.parse(result!.body).message).toBe('Failed to create show');
+  });
+});
+
+// ─── updateShow ─────────────────────────────────────────────────────
+
+describe('updateShow', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('updates show name and returns updated record', async () => {
+    mockGet.mockResolvedValue({ Item: { showId: 's-1', name: 'Raw', companyId: 'c-1' } });
+    mockUpdate.mockResolvedValue({
+      Attributes: { showId: 's-1', name: 'Raw Updated', updatedAt: '2024-01-01' },
+    });
+
+    const event = makeEvent({
+      pathParameters: { showId: 's-1' },
+      body: JSON.stringify({ name: 'Raw Updated' }),
+    });
+
+    const result = await updateShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body).name).toBe('Raw Updated');
+    expect(mockUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('validates new companyId when changing company', async () => {
+    // First call: getOrNotFound for the show
+    // Second call: validate new company exists
+    mockGet
+      .mockResolvedValueOnce({ Item: { showId: 's-1', name: 'Raw', companyId: 'c-1' } })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const event = makeEvent({
+      pathParameters: { showId: 's-1' },
+      body: JSON.stringify({ companyId: 'nonexistent' }),
+    });
+
+    const result = await updateShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(404);
+    expect(JSON.parse(result!.body).message).toContain('Company');
+    expect(JSON.parse(result!.body).message).toContain('not found');
+  });
+
+  it('returns 400 when showId is missing from path', async () => {
+    const event = makeEvent({
+      pathParameters: null,
+      body: JSON.stringify({ name: 'X' }),
+    });
+
+    const result = await updateShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('Show ID is required');
+  });
+
+  it('returns 404 when show does not exist', async () => {
+    mockGet.mockResolvedValue({ Item: undefined });
+
+    const event = makeEvent({
+      pathParameters: { showId: 'nonexistent' },
+      body: JSON.stringify({ name: 'X' }),
+    });
+
+    const result = await updateShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(404);
+    expect(JSON.parse(result!.body).message).toBe('Show not found');
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    mockGet.mockResolvedValue({ Item: { showId: 's-1' } });
+    mockUpdate.mockRejectedValue(new Error('DynamoDB failure'));
+
+    const event = makeEvent({
+      pathParameters: { showId: 's-1' },
+      body: JSON.stringify({ name: 'X' }),
+    });
+
+    const result = await updateShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(500);
+    expect(JSON.parse(result!.body).message).toBe('Failed to update show');
+  });
+});
+
+// ─── deleteShow ─────────────────────────────────────────────────────
+
+describe('deleteShow', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes show and returns 204', async () => {
+    mockGet.mockResolvedValue({ Item: { showId: 's-1', name: 'Raw' } });
+    mockScan.mockResolvedValue({ Items: [] });
+    mockDelete.mockResolvedValue({});
+
+    const event = makeEvent({ pathParameters: { showId: 's-1' } });
+
+    const result = await deleteShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(204);
+    expect(mockDelete).toHaveBeenCalledWith({
+      TableName: 'Shows',
+      Key: { showId: 's-1' },
+    });
+  });
+
+  it('returns 400 when showId is missing from path', async () => {
+    const result = await deleteShow(makeEvent({ pathParameters: null }), ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('Show ID is required');
+  });
+
+  it('returns 404 when show does not exist', async () => {
+    mockGet.mockResolvedValue({ Item: undefined });
+
+    const event = makeEvent({ pathParameters: { showId: 'nonexistent' } });
+
+    const result = await deleteShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(404);
+    expect(JSON.parse(result!.body).message).toBe('Show not found');
+  });
+
+  it('returns 409 when events reference this show', async () => {
+    mockGet.mockResolvedValue({ Item: { showId: 's-1', name: 'Raw' } });
+    mockScan.mockResolvedValue({
+      Items: [
+        { eventId: 'e1', name: 'Raw Episode 1', showId: 's-1' },
+      ],
+    });
+
+    const event = makeEvent({ pathParameters: { showId: 's-1' } });
+
+    const result = await deleteShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(409);
+    expect(JSON.parse(result!.body).message).toContain('1 event(s)');
+    expect(JSON.parse(result!.body).message).toContain('Cannot delete show');
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('deletes when events scan returns undefined Items', async () => {
+    mockGet.mockResolvedValue({ Item: { showId: 's-1', name: 'Raw' } });
+    mockScan.mockResolvedValue({ Items: undefined });
+    mockDelete.mockResolvedValue({});
+
+    const event = makeEvent({ pathParameters: { showId: 's-1' } });
+
+    const result = await deleteShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(204);
+    expect(mockDelete).toHaveBeenCalledOnce();
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    mockGet.mockRejectedValue(new Error('DynamoDB failure'));
+
+    const event = makeEvent({ pathParameters: { showId: 's-1' } });
+
+    const result = await deleteShow(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(500);
+    expect(JSON.parse(result!.body).message).toBe('Failed to delete show');
+  });
+});

--- a/backend/functions/shows/createShow.ts
+++ b/backend/functions/shows/createShow.ts
@@ -1,0 +1,23 @@
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { notFound } from '../../lib/response';
+import { handlerFactory } from '../../lib/handlers';
+
+export const handler = handlerFactory({
+  tableName: TableNames.SHOWS,
+  idField: 'showId',
+  entityName: 'show',
+  requiredFields: ['name', 'companyId'],
+  optionalFields: ['description', 'schedule'],
+  validate: async (body) => {
+    if (body.companyId) {
+      const companyResult = await dynamoDb.get({
+        TableName: TableNames.COMPANIES,
+        Key: { companyId: body.companyId },
+      });
+      if (!companyResult.Item) {
+        return notFound(`Company ${body.companyId} not found`);
+      }
+    }
+    return null;
+  },
+});

--- a/backend/functions/shows/deleteShow.ts
+++ b/backend/functions/shows/deleteShow.ts
@@ -1,0 +1,47 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { getOrNotFound } from '../../lib/dynamodbUtils';
+import { noContent, badRequest, serverError, conflict } from '../../lib/response';
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const showId = event.pathParameters?.showId;
+
+    if (!showId) {
+      return badRequest('Show ID is required');
+    }
+
+    const showResult = await getOrNotFound(TableNames.SHOWS, { showId }, 'Show not found');
+    if ('notFoundResponse' in showResult) {
+      return showResult.notFoundResponse;
+    }
+
+    // Check if any events reference this show
+    const eventsResult = await dynamoDb.scan({
+      TableName: TableNames.EVENTS,
+      FilterExpression: '#showId = :showId',
+      ExpressionAttributeNames: {
+        '#showId': 'showId',
+      },
+      ExpressionAttributeValues: {
+        ':showId': showId,
+      },
+    });
+
+    if (eventsResult.Items && eventsResult.Items.length > 0) {
+      return conflict(
+        `Cannot delete show. ${eventsResult.Items.length} event(s) are still referencing this show.`
+      );
+    }
+
+    await dynamoDb.delete({
+      TableName: TableNames.SHOWS,
+      Key: { showId },
+    });
+
+    return noContent();
+  } catch (err) {
+    console.error('Error deleting show:', err);
+    return serverError('Failed to delete show');
+  }
+};

--- a/backend/functions/shows/getShow.ts
+++ b/backend/functions/shows/getShow.ts
@@ -1,0 +1,27 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { success, badRequest, notFound, serverError } from '../../lib/response';
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const showId = event.pathParameters?.showId;
+
+    if (!showId) {
+      return badRequest('Show ID is required');
+    }
+
+    const result = await dynamoDb.get({
+      TableName: TableNames.SHOWS,
+      Key: { showId },
+    });
+
+    if (!result.Item) {
+      return notFound('Show not found');
+    }
+
+    return success(result.Item);
+  } catch (err) {
+    console.error('Error fetching show:', err);
+    return serverError('Failed to fetch show');
+  }
+};

--- a/backend/functions/shows/getShows.ts
+++ b/backend/functions/shows/getShows.ts
@@ -1,0 +1,41 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { success, serverError } from '../../lib/response';
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const companyId = event.queryStringParameters?.companyId;
+
+    let shows: Record<string, unknown>[];
+
+    if (companyId) {
+      // Query CompanyShowsIndex for shows belonging to a specific company
+      const result = await dynamoDb.query({
+        TableName: TableNames.SHOWS,
+        IndexName: 'CompanyShowsIndex',
+        KeyConditionExpression: '#companyId = :companyId',
+        ExpressionAttributeNames: { '#companyId': 'companyId' },
+        ExpressionAttributeValues: { ':companyId': companyId },
+      });
+      shows = (result.Items || []) as Record<string, unknown>[];
+    } else {
+      // Scan all shows
+      const result = await dynamoDb.scan({
+        TableName: TableNames.SHOWS,
+      });
+      shows = (result.Items || []) as Record<string, unknown>[];
+    }
+
+    // Sort by name ascending
+    shows.sort((a, b) => {
+      const nameA = (a.name as string) || '';
+      const nameB = (b.name as string) || '';
+      return nameA.localeCompare(nameB);
+    });
+
+    return success(shows);
+  } catch (err) {
+    console.error('Error fetching shows:', err);
+    return serverError('Failed to fetch shows');
+  }
+};

--- a/backend/functions/shows/handler.ts
+++ b/backend/functions/shows/handler.ts
@@ -1,0 +1,35 @@
+import { handler as getShowsHandler } from './getShows';
+import { handler as getShowHandler } from './getShow';
+import { handler as createShowHandler } from './createShow';
+import { handler as updateShowHandler } from './updateShow';
+import { handler as deleteShowHandler } from './deleteShow';
+import { createRouter, RouteConfig } from '../../lib/router';
+
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/shows',
+    method: 'GET',
+    handler: getShowsHandler,
+  },
+  {
+    resource: '/shows',
+    method: 'POST',
+    handler: createShowHandler,
+  },
+  {
+    resource: '/shows/{showId}',
+    method: 'GET',
+    handler: getShowHandler,
+  },
+  {
+    resource: '/shows/{showId}',
+    method: 'PUT',
+    handler: updateShowHandler,
+  },
+  {
+    resource: '/shows/{showId}',
+    method: 'DELETE',
+    handler: deleteShowHandler,
+  },
+];
+export const handler = createRouter(routes);

--- a/backend/functions/shows/updateShow.ts
+++ b/backend/functions/shows/updateShow.ts
@@ -1,0 +1,66 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { buildUpdateExpression, getOrNotFound } from '../../lib/dynamodbUtils';
+import { success, badRequest, notFound, serverError } from '../../lib/response';
+import { parseBody } from '../../lib/parseBody';
+
+interface UpdateShowBody {
+  name?: string;
+  companyId?: string;
+  description?: string;
+  schedule?: string;
+}
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const showId = event.pathParameters?.showId;
+
+    if (!showId) {
+      return badRequest('Show ID is required');
+    }
+
+    const { data: body, error: parseError } = parseBody<UpdateShowBody>(event);
+    if (parseError) return parseError;
+
+    const showResult = await getOrNotFound(TableNames.SHOWS, { showId }, 'Show not found');
+    if ('notFoundResponse' in showResult) {
+      return showResult.notFoundResponse;
+    }
+
+    // If companyId is being changed, validate the new company exists
+    if (body.companyId !== undefined) {
+      const companyResult = await dynamoDb.get({
+        TableName: TableNames.COMPANIES,
+        Key: { companyId: body.companyId },
+      });
+      if (!companyResult.Item) {
+        return notFound(`Company ${body.companyId} not found`);
+      }
+    }
+
+    const updateExpr = buildUpdateExpression({
+      name: body.name,
+      companyId: body.companyId,
+      description: body.description,
+      schedule: body.schedule,
+    });
+
+    if (!updateExpr.hasChanges) {
+      return badRequest('No valid fields to update');
+    }
+
+    const result = await dynamoDb.update({
+      TableName: TableNames.SHOWS,
+      Key: { showId },
+      UpdateExpression: updateExpr.UpdateExpression,
+      ExpressionAttributeNames: updateExpr.ExpressionAttributeNames,
+      ExpressionAttributeValues: updateExpr.ExpressionAttributeValues,
+      ReturnValues: 'ALL_NEW',
+    });
+
+    return success(result.Attributes);
+  } catch (err) {
+    console.error('Error updating show:', err);
+    return serverError('Failed to update show');
+  }
+};

--- a/backend/functions/wrestlers/__tests__/wrestlers.test.ts
+++ b/backend/functions/wrestlers/__tests__/wrestlers.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../../lib/dynamodb', () => ({
     CHAMPIONSHIPS: 'Championships',
     SEASON_STANDINGS: 'SeasonStandings',
     SEASONS: 'Seasons',
+    COMPANIES: 'Companies',
   },
 }));
 

--- a/backend/functions/wrestlers/createWrestler.ts
+++ b/backend/functions/wrestlers/createWrestler.ts
@@ -7,7 +7,7 @@ export const handler = handlerFactory({
   idField: 'wrestlerId',
   entityName: 'wrestler',
   requiredFields: ['name'],
-  optionalFields: ['imageUrl', 'divisionId', 'nickname', 'finisher', 'weight', 'height', 'hometown', 'alignment'],
+  optionalFields: ['imageUrl', 'divisionId', 'nickname', 'finisher', 'weight', 'height', 'hometown', 'alignment', 'companyId'],
   defaults: {
     wins: 0,
     losses: 0,
@@ -21,6 +21,15 @@ export const handler = handlerFactory({
       });
       if (!divisionResult.Item) {
         return notFound(`Division ${body.divisionId} not found`);
+      }
+    }
+    if (body.companyId) {
+      const companyResult = await dynamoDb.get({
+        TableName: TableNames.COMPANIES,
+        Key: { companyId: body.companyId },
+      });
+      if (!companyResult.Item) {
+        return notFound('Company not found');
       }
     }
     if (body.alignment && !['face', 'heel', 'tweener'].includes(body.alignment as string)) {

--- a/backend/functions/wrestlers/getWrestlers.ts
+++ b/backend/functions/wrestlers/getWrestlers.ts
@@ -2,8 +2,35 @@ import { APIGatewayProxyHandler } from 'aws-lambda';
 import { dynamoDb, TableNames } from '../../lib/dynamodb';
 import { success, serverError } from '../../lib/response';
 
-export const handler: APIGatewayProxyHandler = async () => {
+export const handler: APIGatewayProxyHandler = async (event) => {
   try {
+    const companyId = event.queryStringParameters?.companyId;
+    const unassigned = event.queryStringParameters?.unassigned;
+
+    if (companyId) {
+      // Filter wrestlers by companyId using FilterExpression on scan
+      const result = await dynamoDb.scan({
+        TableName: TableNames.WRESTLERS,
+        FilterExpression: '#companyId = :companyId',
+        ExpressionAttributeNames: { '#companyId': 'companyId' },
+        ExpressionAttributeValues: { ':companyId': companyId },
+      });
+
+      return success(result.Items || []);
+    }
+
+    if (unassigned === 'true') {
+      // Filter wrestlers with no companyId
+      const result = await dynamoDb.scan({
+        TableName: TableNames.WRESTLERS,
+        FilterExpression: 'attribute_not_exists(#companyId) OR #companyId = :empty',
+        ExpressionAttributeNames: { '#companyId': 'companyId' },
+        ExpressionAttributeValues: { ':empty': '' },
+      });
+
+      return success(result.Items || []);
+    }
+
     const result = await dynamoDb.scan({
       TableName: TableNames.WRESTLERS,
     });

--- a/backend/functions/wrestlers/updateWrestler.ts
+++ b/backend/functions/wrestlers/updateWrestler.ts
@@ -50,6 +50,24 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       }
     }
 
+    if (body.companyId !== undefined) {
+      if (body.companyId === '' || body.companyId === null) {
+        // Remove companyId if empty string or null (unassign from company)
+        removeFields.push('companyId');
+      } else {
+        // Validate that the company exists
+        const companyResult = await getOrNotFound(
+          TableNames.COMPANIES,
+          { companyId: body.companyId },
+          `Company ${body.companyId} not found`
+        );
+        if ('notFoundResponse' in companyResult) {
+          return companyResult.notFoundResponse;
+        }
+        updateFields.companyId = body.companyId;
+      }
+    }
+
     const updateExpr = buildUpdateExpression(updateFields, {
       removeFields,
     });

--- a/backend/lib/dynamodb.ts
+++ b/backend/lib/dynamodb.ts
@@ -131,6 +131,8 @@ export const TableNames = {
   STIPULATIONS: process.env.STIPULATIONS_TABLE!,
   MATCH_TYPES: process.env.MATCH_TYPES_TABLE!,
   SEASON_AWARDS: process.env.SEASON_AWARDS_TABLE!,
+  COMPANIES: process.env.COMPANIES_TABLE!,
+  SHOWS: process.env.SHOWS_TABLE!,
 };
 
 type DynamoRecord = Record<string, unknown>;

--- a/backend/scripts/create-tables.ts
+++ b/backend/scripts/create-tables.ts
@@ -202,6 +202,30 @@ const tables = [
     AttributeDefinitions: [{ AttributeName: 'matchTypeId', AttributeType: 'S' }],
     BillingMode: 'PAY_PER_REQUEST',
   },
+  {
+    TableName: `universe-tracker-api-companies-${STAGE}`,
+    KeySchema: [{ AttributeName: 'companyId', KeyType: 'HASH' }],
+    AttributeDefinitions: [{ AttributeName: 'companyId', AttributeType: 'S' }],
+    BillingMode: 'PAY_PER_REQUEST',
+  },
+  {
+    TableName: `universe-tracker-api-shows-${STAGE}`,
+    KeySchema: [{ AttributeName: 'showId', KeyType: 'HASH' }],
+    AttributeDefinitions: [
+      { AttributeName: 'showId', AttributeType: 'S' },
+      { AttributeName: 'companyId', AttributeType: 'S' },
+    ],
+    BillingMode: 'PAY_PER_REQUEST',
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: 'CompanyShowsIndex',
+        KeySchema: [
+          { AttributeName: 'companyId', KeyType: 'HASH' },
+        ],
+        Projection: { ProjectionType: 'ALL' },
+      },
+    ],
+  },
 ];
 
 async function createTables() {

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -26,6 +26,8 @@ provider:
     STIPULATIONS_TABLE: ${self:service}-stipulations-${self:provider.stage}
     MATCH_TYPES_TABLE: ${self:service}-match-types-${self:provider.stage}
     SEASON_AWARDS_TABLE: ${self:service}-season-awards-${self:provider.stage}
+    COMPANIES_TABLE: ${self:service}-companies-${self:provider.stage}
+    SHOWS_TABLE: ${self:service}-shows-${self:provider.stage}
     DYNAMODB_ENDPOINT: ${env:DYNAMODB_ENDPOINT, 'http://localhost:8000'}
     COGNITO_USER_POOL_ID: 'us-east-1_5GZ9UY8V2'
     COGNITO_CLIENT_ID: '5bn99khg7knh9v0t5dqbjpgh1d'
@@ -64,6 +66,9 @@ provider:
             - arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.STIPULATIONS_TABLE}
             - arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.MATCH_TYPES_TABLE}
             - arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.SEASON_AWARDS_TABLE}
+            - arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.COMPANIES_TABLE}
+            - arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.SHOWS_TABLE}
+            - arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.SHOWS_TABLE}/index/*
         - Effect: Allow
           Action:
             - s3:PutObject
@@ -446,6 +451,34 @@ functions:
           cors: *corsConfig
           authorizer: adminAuthorizer
 
+  # Companies (CRUD for wrestling companies/promotions)
+  companies:
+    handler: functions/companies/handler.handler
+    events:
+      - http:
+          path: companies
+          method: any
+          cors: *corsConfig
+      - http:
+          path: companies/{companyId}
+          method: any
+          cors: *corsConfig
+          authorizer: adminAuthorizer
+
+  # Shows (CRUD for TV shows/programs)
+  shows:
+    handler: functions/shows/handler.handler
+    events:
+      - http:
+          path: shows
+          method: any
+          cors: *corsConfig
+      - http:
+          path: shows/{showId}
+          method: any
+          cors: *corsConfig
+          authorizer: adminAuthorizer
+
   # Contenders (Phase 3 consolidated: getContenders, calculateRankings)
   contenders:
     handler: functions/contenders/handler.handler
@@ -562,9 +595,18 @@ resources:
         AttributeDefinitions:
           - AttributeName: wrestlerId
             AttributeType: S
+          - AttributeName: companyId
+            AttributeType: S
         KeySchema:
           - AttributeName: wrestlerId
             KeyType: HASH
+        GlobalSecondaryIndexes:
+          - IndexName: CompanyIndex
+            KeySchema:
+              - AttributeName: companyId
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL
 
     MatchesTable:
       Type: AWS::DynamoDB::Table
@@ -832,6 +874,39 @@ resources:
             KeyType: HASH
           - AttributeName: awardId
             KeyType: RANGE
+
+    CompaniesTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:provider.environment.COMPANIES_TABLE}
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: companyId
+            AttributeType: S
+        KeySchema:
+          - AttributeName: companyId
+            KeyType: HASH
+
+    ShowsTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:provider.environment.SHOWS_TABLE}
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: showId
+            AttributeType: S
+          - AttributeName: companyId
+            AttributeType: S
+        KeySchema:
+          - AttributeName: showId
+            KeyType: HASH
+        GlobalSecondaryIndexes:
+          - IndexName: CompanyShowsIndex
+            KeySchema:
+              - AttributeName: companyId
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL
 
     ImagesBucket:
       Type: AWS::S3::Bucket

--- a/docs/plans/plan-issue-4-companies-and-shows-do.md
+++ b/docs/plans/plan-issue-4-companies-and-shows-do.md
@@ -1,0 +1,297 @@
+# Plan: Add Companies and Shows with multi-company events
+
+**GitHub issue:** #4 — [Add Companies and Shows with multi-company events](https://github.com/jpDxsoloOrg/universe_tracker/issues/4)
+
+## Context
+
+Companies are the core organizational unit in WWE Universe Mode. A company owns a roster of wrestlers, divisions, and championships. Shows are programming a company runs (e.g., "Monday Nitro", "Raw"). Events can be hosted by one or more companies — when booking matches, the available wrestler pool is the union of all hosting companies' rosters.
+
+## Skills to use
+
+| When | Skill | Purpose |
+|------|--------|---------|
+| Before commit | git-commit-helper | Generate conventional commit message |
+
+## Agents and parallel work
+
+- **Suggested order**: Steps 1+2+3 in parallel → Step 4 → Step 5
+- **Agent types**:
+  - Step 1: `general-purpose` (backend Companies CRUD + Shows CRUD + serverless.yml + dynamodb.ts)
+  - Step 2: `general-purpose` (backend updates to existing entities: Wrestlers, Events, Championships, Divisions + seed data)
+  - Step 3: `general-purpose` (all frontend: types, API services, admin components, i18n, routes)
+  - Step 4: `general-purpose` (backend match booking validation + frontend match scheduling filter)
+  - Step 5: `general-purpose` (verification and cleanup)
+
+## Implementation steps
+
+### Step 1: Backend new entity CRUD (Companies + Shows)
+
+Create the Companies and Shows entities in the backend following existing patterns.
+
+**1. serverless.yml changes:**
+
+Add environment variables:
+```yaml
+COMPANIES_TABLE: ${self:service}-companies-${self:provider.stage}
+SHOWS_TABLE: ${self:service}-shows-${self:provider.stage}
+```
+
+Add IAM permissions for new tables (follow existing pattern - add to the DynamoDB Action list's Resource array).
+
+Add Lambda function definitions:
+```yaml
+companies:
+  handler: functions/companies/handler.handler
+  events:
+    - http:
+        path: companies
+        method: any
+        cors: *corsConfig
+    - http:
+        path: companies/{companyId}
+        method: any
+        cors: *corsConfig
+        authorizer: adminAuthorizer
+
+shows:
+  handler: functions/shows/handler.handler
+  events:
+    - http:
+        path: shows
+        method: any
+        cors: *corsConfig
+    - http:
+        path: shows/{showId}
+        method: any
+        cors: *corsConfig
+        authorizer: adminAuthorizer
+```
+
+Add DynamoDB table resources:
+```yaml
+CompaniesTable:
+  Type: AWS::DynamoDB::Table
+  Properties:
+    TableName: ${self:provider.environment.COMPANIES_TABLE}
+    BillingMode: PAY_PER_REQUEST
+    AttributeDefinitions:
+      - AttributeName: companyId
+        AttributeType: S
+    KeySchema:
+      - AttributeName: companyId
+        KeyType: HASH
+
+ShowsTable:
+  Type: AWS::DynamoDB::Table
+  Properties:
+    TableName: ${self:provider.environment.SHOWS_TABLE}
+    BillingMode: PAY_PER_REQUEST
+    AttributeDefinitions:
+      - AttributeName: showId
+        AttributeType: S
+      - AttributeName: companyId
+        AttributeType: S
+    KeySchema:
+      - AttributeName: showId
+        KeyType: HASH
+    GlobalSecondaryIndexes:
+      - IndexName: CompanyShowsIndex
+        KeySchema:
+          - AttributeName: companyId
+            KeyType: HASH
+        Projection:
+          ProjectionType: ALL
+```
+
+Add CompanyIndex GSI to WrestlersTable:
+```yaml
+# Add to WrestlersTable AttributeDefinitions:
+- AttributeName: companyId
+  AttributeType: S
+# Add GSI:
+- IndexName: CompanyIndex
+  KeySchema:
+    - AttributeName: companyId
+      KeyType: HASH
+  Projection:
+    ProjectionType: ALL
+```
+
+**2. backend/lib/dynamodb.ts:**
+Add `COMPANIES: process.env.COMPANIES_TABLE!` and `SHOWS: process.env.SHOWS_TABLE!` to TableNames.
+
+**3. backend/functions/companies/ (new directory):**
+
+Create following existing patterns:
+- `handler.ts` - createRouter with routes for GET/POST /companies, GET/PUT/DELETE /companies/{companyId}
+- `createCompany.ts` - Use handlerFactory: requiredFields=['name'], optionalFields=['abbreviation', 'imageUrl', 'description'], idField='companyId', entityName='company'
+- `getCompanies.ts` - Scan CompaniesTable, return all
+- `getCompany.ts` - Get by companyId, enrich with roster count (scan wrestlers with companyId filter)
+- `updateCompany.ts` - Standard update pattern with buildUpdateExpression
+- `deleteCompany.ts` - Check for assigned wrestlers first (scan WrestlersTable for companyId), block if any found. Also check for shows.
+
+**4. backend/functions/shows/ (new directory):**
+- `handler.ts` - createRouter with routes
+- `createShow.ts` - Use handlerFactory: requiredFields=['name', 'companyId'], optionalFields=['description', 'schedule'], idField='showId', entityName='show'. Validate companyId exists.
+- `getShows.ts` - Support ?companyId= filter (query CompanyShowsIndex), fall back to scan
+- `getShow.ts` - Get by showId
+- `updateShow.ts` - Standard update, validate companyId if changed
+- `deleteShow.ts` - Standard delete, check for events using this show
+
+**5. backend/scripts/create-tables.ts:**
+Add CompaniesTable and ShowsTable definitions.
+
+### Step 2: Backend updates to existing entities
+
+Update Wrestlers, Events, Championships, and Divisions to support companyId.
+
+**1. Wrestlers:**
+- `createWrestler.ts` - Add 'companyId' to optionalFields. In validate(), if companyId provided, verify company exists.
+- `updateWrestler.ts` - Allow setting/clearing companyId. Validate company exists if provided.
+- `getWrestlers.ts` - Support `?companyId=` query param to filter by company. Support `?unassigned=true` for global pool (no companyId).
+
+**2. Events:**
+- `createEvent.ts` - Add 'companyIds' to optionalFields (array of company IDs). Validate all companyIds exist.
+- `updateEvent.ts` - Allow updating companyIds. Validate.
+- `getEvents.ts` - Return companyIds in response.
+- `getEvent.ts` - Return companyIds, enrich with company names.
+
+**3. Championships:**
+- `createChampionship.ts` - Add 'companyId' to optionalFields. Validate if provided.
+- `updateChampionship.ts` - Allow setting companyId.
+
+Note: Check if championships use handlerFactory or custom handlers.
+
+**4. Divisions:**
+- Division handler already exists. Add 'companyId' to optionalFields in create. Add to update allowed fields.
+
+**5. Seed data:**
+- `backend/functions/admin/seedData.ts` - Add sample companies (e.g., "WWF", "WCW", "ECW"), sample shows, assign wrestlers to companies.
+- `backend/scripts/seed-data.ts` - Same updates.
+
+**6. Clear data:**
+- `backend/functions/admin/clearAll.ts` - Add COMPANIES and SHOWS tables to clear list.
+
+**7. Data transfer:**
+- `backend/functions/admin/dataTransferConfig.ts` - Add Companies and Shows to datasets.
+
+### Step 3: All frontend changes
+
+**1. Types (`frontend/src/types/index.ts` or new file):**
+
+Add Company interface:
+```typescript
+export interface Company {
+  companyId: string;
+  name: string;
+  abbreviation?: string;
+  imageUrl?: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+Add Show interface:
+```typescript
+export interface Show {
+  showId: string;
+  name: string;
+  companyId: string;
+  description?: string;
+  schedule?: 'weekly' | 'ppv' | 'special';
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+Update Wrestler: add `companyId?: string`
+Update Championship: add `companyId?: string`
+Update Division: add `companyId?: string`
+Update LeagueEvent (in event.ts): add `companyIds?: string[]`, `showId?: string`
+
+**2. API services:**
+
+Create `frontend/src/services/api/companies.api.ts`:
+- Use crudFactory or custom: getAll, getById, create, update, delete
+
+Create `frontend/src/services/api/shows.api.ts`:
+- getAll (with ?companyId= filter), getById, create, update, delete
+
+Export from `frontend/src/services/api/index.ts`.
+
+**3. Admin components:**
+
+Create `frontend/src/components/admin/ManageCompanies.tsx` + CSS:
+- List companies with edit/delete
+- Create form: name (required), abbreviation, description, image upload
+- Show roster count per company
+- Follow ManageDivisions.tsx pattern
+
+Create `frontend/src/components/admin/ManageShows.tsx` + CSS:
+- List shows grouped by company
+- Create form: name (required), company selector (required), schedule type, description
+- Follow ManageDivisions.tsx pattern
+
+**4. AdminPanel.tsx:**
+Add 'companies' and 'shows' tabs. Companies should come early in the tab order (after wrestlers).
+
+**5. App.tsx:**
+No new public routes needed for now (companies/shows are admin-managed).
+
+**6. i18n:**
+Add translation keys for companies and shows in en.json and de.json:
+- companies section: name, abbreviation, description, createCompany, editCompany, deleteCompany, noCompanies, confirmDelete, rosterCount, etc.
+- shows section: similar pattern
+
+**7. Update existing components:**
+- CreateEvent.tsx: Add multi-select for hosting companyIds
+- ManageWrestlers.tsx: Add company selector dropdown when creating/editing
+- ManageChampionships.tsx: Add company selector
+- ManageDivisions.tsx: Add company selector
+
+### Step 4: Match booking roster filtering
+
+**1. Backend (`backend/functions/matches/scheduleMatch.ts`):**
+- If match has eventId, look up event's companyIds
+- Validate all participant wrestlers belong to one of the hosting companies' rosters
+- If no eventId, allow any wrestler
+
+**2. Frontend (`frontend/src/components/admin/ScheduleMatch.tsx`):**
+- When event is selected, fetch event details to get companyIds
+- Filter wrestler picker to show only wrestlers from those companies + unassigned pool
+- If no event selected, show all wrestlers
+
+### Step 5: Verification and cleanup
+
+1. Run `cd backend && npx tsc --project tsconfig.json --noEmit`
+2. Run `cd frontend && npx tsc --project tsconfig.app.json --noEmit`
+3. Run backend tests
+4. Run frontend tests
+5. Fix any failures
+6. Search for inconsistencies
+
+## Dependencies and order
+
+- Steps 1, 2, and 3 can run in parallel (no file overlap)
+- Step 4 depends on Steps 1+2+3
+- Step 5 depends on Step 4
+
+**Suggested order:** Steps 1+2+3 → Step 4 → Step 5
+
+## Testing and verification
+
+- TypeScript compilation passes (both frontend and backend)
+- All existing tests pass
+- New CRUD endpoints return correct responses
+- Company deletion blocked when wrestlers assigned
+- Show deletion blocked when events reference it
+- Wrestlers filterable by companyId
+- Events accept companyIds array
+- Match booking validates roster membership
+
+## Risks and edge cases
+
+- **CompanyIndex GSI on Wrestlers**: Adding GSI to existing table requires careful schema definition. Since we haven't deployed yet, this is safe.
+- **Backward compatibility**: Existing data has no companyId. All companyId fields are optional, so existing entities work fine.
+- **Multi-company events**: Union of rosters may have duplicates if a wrestler is somehow assigned to multiple companies. wrestlerId should be unique so dedup is natural.

--- a/frontend/src/components/admin/AdminPanel.tsx
+++ b/frontend/src/components/admin/AdminPanel.tsx
@@ -19,10 +19,12 @@ import './AdminPanel.css';
 
 import ManageSeasonAwards from './ManageSeasonAwards';
 import AdminContenderConfig from './AdminContenderConfig';
+import ManageCompanies from './ManageCompanies';
+import ManageShows from './ManageShows';
 
-type AdminTab = 'wrestlers' | 'divisions' | 'match-config' | 'schedule' | 'results' | 'championships' | 'tournaments' | 'seasons' | 'season-awards' | 'events' | 'contender-config' | 'danger' | 'features';
+type AdminTab = 'wrestlers' | 'divisions' | 'companies' | 'shows' | 'match-config' | 'schedule' | 'results' | 'championships' | 'tournaments' | 'seasons' | 'season-awards' | 'events' | 'contender-config' | 'danger' | 'features';
 
-const VALID_TABS: AdminTab[] = ['wrestlers', 'divisions', 'match-config', 'schedule', 'results', 'championships', 'tournaments', 'seasons', 'season-awards', 'events', 'contender-config', 'danger', 'features'];
+const VALID_TABS: AdminTab[] = ['wrestlers', 'divisions', 'companies', 'shows', 'match-config', 'schedule', 'results', 'championships', 'tournaments', 'seasons', 'season-awards', 'events', 'contender-config', 'danger', 'features'];
 
 
 export default function AdminPanel() {
@@ -62,6 +64,8 @@ export default function AdminPanel() {
     features: <ManageFeatures />,
     wrestlers: <ManageWrestlers />,
     divisions: <ManageDivisions />,
+    companies: <ManageCompanies />,
+    shows: <ManageShows />,
     'match-config': <ManageMatchConfig />,
     schedule: <ScheduleMatch />,
     results: <RecordResult />,

--- a/frontend/src/components/admin/CreateEvent.css
+++ b/frontend/src/components/admin/CreateEvent.css
@@ -100,6 +100,30 @@
   border-radius: 4px;
 }
 
+/* ── Company Checkboxes ────────────────────────────────────────────────────── */
+
+.company-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.company-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #ccc;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.company-checkbox-label input[type="checkbox"] {
+  accent-color: #d4af37;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
 /* ── Save Button ───────────────────────────────────────────────────────────── */
 
 .save-event-btn {

--- a/frontend/src/components/admin/CreateEvent.tsx
+++ b/frontend/src/components/admin/CreateEvent.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { EventType, LeagueEvent } from '../../types/event';
-import type { Season } from '../../types';
-import { eventsApi, seasonsApi } from '../../services/api';
+import type { Season, Company } from '../../types';
+import { eventsApi, seasonsApi, companiesApi } from '../../services/api';
 import './CreateEvent.css';
 
 const eventTypeOptions: { value: EventType; labelKey: string }[] = [
@@ -46,7 +46,9 @@ export default function CreateEvent() {
   const [description, setDescription] = useState('');
   const [themeColor, setThemeColor] = useState('#d4af37');
   const [seasonId, setSeasonId] = useState('');
+  const [selectedCompanyIds, setSelectedCompanyIds] = useState<string[]>([]);
   const [seasons, setSeasons] = useState<Season[]>([]);
+  const [companies, setCompanies] = useState<Company[]>([]);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -62,6 +64,7 @@ export default function CreateEvent() {
 
   useEffect(() => {
     seasonsApi.getAll().then(setSeasons).catch(() => {});
+    companiesApi.getAll().then(setCompanies).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -98,6 +101,7 @@ export default function CreateEvent() {
         description: description || undefined,
         themeColor,
         seasonId: seasonId || undefined,
+        companyIds: selectedCompanyIds.length > 0 ? selectedCompanyIds : undefined,
       });
       setSaved(true);
       setEvents((prev) => [created, ...prev]);
@@ -106,6 +110,7 @@ export default function CreateEvent() {
       setVenue('');
       setDescription('');
       setSeasonId('');
+      setSelectedCompanyIds([]);
       setTimeout(() => setSaved(false), 3000);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create event');
@@ -281,6 +286,31 @@ export default function CreateEvent() {
             ))}
           </select>
         </div>
+
+        {/* Companies */}
+        {companies.length > 0 && (
+          <div className="form-group">
+            <label className="form-label">{t('companies.title')}</label>
+            <div className="company-checkboxes">
+              {companies.map((company) => (
+                <label key={company.companyId} className="company-checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={selectedCompanyIds.includes(company.companyId)}
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        setSelectedCompanyIds(prev => [...prev, company.companyId]);
+                      } else {
+                        setSelectedCompanyIds(prev => prev.filter(id => id !== company.companyId));
+                      }
+                    }}
+                  />
+                  <span>{company.name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Save Button */}
         <button

--- a/frontend/src/components/admin/ManageChampionships.tsx
+++ b/frontend/src/components/admin/ManageChampionships.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, FormEvent, ChangeEvent } from 'react';
-import { championshipsApi, divisionsApi, wrestlersApi, imagesApi } from '../../services/api';
+import { championshipsApi, divisionsApi, wrestlersApi, imagesApi, companiesApi } from '../../services/api';
 import { sanitizeName } from '../../utils/sanitize';
 import { logger } from '../../utils/logger';
 import { FILE_UPLOAD_LIMITS, VALIDATION } from '../../constants';
@@ -8,7 +8,7 @@ import {
   applyImageFallback,
   resolveImageSrc,
 } from '../../constants/imageFallbacks';
-import type { Championship, Division, Wrestler } from '../../types';
+import type { Championship, Division, Wrestler, Company } from '../../types';
 import './ManageChampionships.css';
 
 export default function ManageChampionships() {
@@ -25,11 +25,13 @@ export default function ManageChampionships() {
 
   const [divisions, setDivisions] = useState<Division[]>([]);
   const [wrestlers, setWrestlers] = useState<Wrestler[]>([]);
+  const [companies, setCompanies] = useState<Company[]>([]);
 
   const [formData, setFormData] = useState({
     name: '',
     type: 'singles' as 'singles' | 'tag',
     divisionId: '',
+    companyId: '',
     imageUrl: '',
   });
 
@@ -41,6 +43,7 @@ export default function ManageChampionships() {
     loadChampionships();
     loadDivisions();
     loadWrestlers();
+    loadCompanies();
   }, []);
 
   const loadChampionships = async () => {
@@ -71,6 +74,21 @@ export default function ManageChampionships() {
     } catch (_err) {
       // Non-critical — used for champion display
     }
+  };
+
+  const loadCompanies = async () => {
+    try {
+      const data = await companiesApi.getAll();
+      setCompanies(data);
+    } catch (_err) {
+      // Non-critical — companies are optional
+    }
+  };
+
+  const getCompanyName = (companyId?: string) => {
+    if (!companyId) return 'None';
+    const company = companies.find(c => c.companyId === companyId);
+    return company ? company.name : 'Unknown';
   };
 
   const getChampionName = (currentChampion?: string | string[]): string => {
@@ -189,6 +207,7 @@ export default function ManageChampionships() {
           name: sanitizedName,
           type: formData.type,
           divisionId: formData.divisionId || undefined,
+          companyId: formData.companyId || undefined,
           imageUrl: imageUrl || undefined,
         });
         setSuccess('Championship updated successfully!');
@@ -197,13 +216,14 @@ export default function ManageChampionships() {
           name: sanitizedName,
           type: formData.type,
           divisionId: formData.divisionId || undefined,
+          companyId: formData.companyId || undefined,
           imageUrl: imageUrl || undefined,
           isActive: true,
         });
         setSuccess('Championship created successfully!');
       }
 
-      setFormData({ name: '', type: 'singles', divisionId: '', imageUrl: '' });
+      setFormData({ name: '', type: 'singles', divisionId: '', companyId: '', imageUrl: '' });
       setSelectedFile(null);
       setImagePreview(null);
       setShowAddForm(false);
@@ -222,6 +242,7 @@ export default function ManageChampionships() {
       name: championship.name,
       type: championship.type,
       divisionId: championship.divisionId || '',
+      companyId: championship.companyId || '',
       imageUrl: championship.imageUrl || '',
     });
     setImagePreview(championship.imageUrl || null);
@@ -230,7 +251,7 @@ export default function ManageChampionships() {
   };
 
   const handleCancel = () => {
-    setFormData({ name: '', type: 'singles', divisionId: '', imageUrl: '' });
+    setFormData({ name: '', type: 'singles', divisionId: '', companyId: '', imageUrl: '' });
     setSelectedFile(null);
     setImagePreview(null);
     setShowAddForm(false);
@@ -341,6 +362,22 @@ export default function ManageChampionships() {
             </div>
 
             <div className="form-group">
+              <label htmlFor="companyId">Company</label>
+              <select
+                id="companyId"
+                value={formData.companyId}
+                onChange={(e) => setFormData({ ...formData, companyId: e.target.value })}
+              >
+                <option value="">No Company</option>
+                {companies.map((company) => (
+                  <option key={company.companyId} value={company.companyId}>
+                    {company.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="form-group">
               <label htmlFor="championship-image">Championship Belt Image</label>
               <div className="image-upload-container">
                 {imagePreview ? (
@@ -397,6 +434,9 @@ export default function ManageChampionships() {
                 <h4>{championship.name}</h4>
                 <div className="championship-type">
                   {championship.type === 'singles' ? 'Singles' : 'Tag Team'}
+                </div>
+                <div className="championship-company">
+                  Company: {getCompanyName(championship.companyId)}
                 </div>
                 <div className="championship-division">
                   Division: {getDivisionName(championship.divisionId)}

--- a/frontend/src/components/admin/ManageCompanies.css
+++ b/frontend/src/components/admin/ManageCompanies.css
@@ -1,0 +1,149 @@
+.manage-companies {
+  width: 100%;
+}
+
+.companies-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.company-form-container {
+  background-color: #1a1a1a;
+  border: 2px solid #d4af37;
+  border-radius: 8px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+
+.company-form-container h3 {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  color: #d4af37;
+}
+
+.company-form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.company-form textarea {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: #222;
+  border: 2px solid #444;
+  border-radius: 4px;
+  color: #fff;
+  font-family: inherit;
+  font-size: 1rem;
+  resize: vertical;
+}
+
+.company-form textarea:focus {
+  outline: none;
+  border-color: #d4af37;
+}
+
+.companies-list h3 {
+  margin-bottom: 1.5rem;
+}
+
+.companies-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.company-card {
+  background-color: #1a1a1a;
+  border: 2px solid #d4af37;
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+
+.company-card h4 {
+  margin: 0 0 0.5rem 0;
+  color: #d4af37;
+  font-size: 1.25rem;
+}
+
+.company-abbreviation {
+  display: inline-block;
+  background-color: #333;
+  color: #d4af37;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: bold;
+  margin-bottom: 0.75rem;
+}
+
+.company-description {
+  color: #bbb;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.company-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #333;
+}
+
+.company-edit-btn {
+  background-color: #3b82f6;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  flex: 1;
+}
+
+.company-edit-btn:hover {
+  background-color: #2563eb;
+}
+
+.company-delete-btn {
+  background-color: #7f1d1d !important;
+  color: #fecaca;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  flex: 1;
+}
+
+.company-delete-btn:hover:not(:disabled) {
+  background-color: #991b1b !important;
+}
+
+.company-delete-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+  color: #888;
+}
+
+@media (max-width: 768px) {
+  .companies-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .company-form-container {
+    padding: 1rem;
+  }
+
+  .companies-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .company-card {
+    padding: 1rem;
+  }
+}

--- a/frontend/src/components/admin/ManageCompanies.tsx
+++ b/frontend/src/components/admin/ManageCompanies.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect, FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { companiesApi } from '../../services/api';
+import type { Company } from '../../types';
+import Skeleton from '../ui/Skeleton';
+import './ManageCompanies.css';
+
+export default function ManageCompanies() {
+  const { t } = useTranslation();
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [editingCompany, setEditingCompany] = useState<Company | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const [formData, setFormData] = useState({
+    name: '',
+    abbreviation: '',
+    description: '',
+  });
+
+  useEffect(() => {
+    loadCompanies();
+  }, []);
+
+  const loadCompanies = async () => {
+    try {
+      setLoading(true);
+      const data = await companiesApi.getAll();
+      setCompanies(data);
+    } catch (_err) {
+      setError(t('companies.noCompanies'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    try {
+      if (editingCompany) {
+        await companiesApi.update(editingCompany.companyId, {
+          name: formData.name,
+          abbreviation: formData.abbreviation || undefined,
+          description: formData.description || undefined,
+        });
+        setSuccess(t('companies.edit') + ' - OK');
+      } else {
+        await companiesApi.create({
+          name: formData.name,
+          abbreviation: formData.abbreviation || undefined,
+          description: formData.description || undefined,
+        });
+        setSuccess(t('companies.create') + ' - OK');
+      }
+
+      setFormData({ name: '', abbreviation: '', description: '' });
+      setShowAddForm(false);
+      setEditingCompany(null);
+      await loadCompanies();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save company');
+    }
+  };
+
+  const handleEdit = (company: Company) => {
+    setEditingCompany(company);
+    setFormData({
+      name: company.name,
+      abbreviation: company.abbreviation || '',
+      description: company.description || '',
+    });
+    setShowAddForm(true);
+  };
+
+  const handleDelete = async (companyId: string) => {
+    if (!confirm(t('companies.confirmDelete'))) {
+      return;
+    }
+
+    setDeleting(companyId);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      await companiesApi.delete(companyId);
+      setSuccess(t('companies.delete') + ' - OK');
+      await loadCompanies();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('companies.deleteBlocked'));
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const handleCancel = () => {
+    setFormData({ name: '', abbreviation: '', description: '' });
+    setShowAddForm(false);
+    setEditingCompany(null);
+  };
+
+  if (loading) {
+    return <Skeleton variant="block" count={4} />;
+  }
+
+  return (
+    <div className="manage-companies">
+      <div className="companies-header">
+        <h2>{t('companies.title')}</h2>
+        {!showAddForm && (
+          <button onClick={() => setShowAddForm(true)}>
+            {t('companies.create')}
+          </button>
+        )}
+      </div>
+
+      {error && <div className="error-message">{error}</div>}
+      {success && <div className="success-message">{success}</div>}
+
+      {showAddForm && (
+        <div className="company-form-container">
+          <h3>{editingCompany ? t('companies.edit') : t('companies.create')}</h3>
+          <form onSubmit={handleSubmit} className="company-form">
+            <div className="form-group">
+              <label htmlFor="company-name">{t('companies.name')}</label>
+              <input
+                type="text"
+                id="company-name"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                required
+                placeholder="e.g., WWE, AEW, NJPW"
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="company-abbreviation">{t('companies.abbreviation')}</label>
+              <input
+                type="text"
+                id="company-abbreviation"
+                value={formData.abbreviation}
+                onChange={(e) => setFormData({ ...formData, abbreviation: e.target.value })}
+                placeholder="e.g., WWE, AEW"
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="company-description">{t('companies.description')}</label>
+              <textarea
+                id="company-description"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                placeholder="Brief description of this company"
+                rows={3}
+              />
+            </div>
+
+            <div className="form-actions">
+              <button type="submit">
+                {editingCompany ? t('companies.edit') : t('companies.create')}
+              </button>
+              <button type="button" onClick={handleCancel} className="cancel-btn">
+                {t('common.cancel')}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      <div className="companies-list">
+        <h3>{t('companies.title')} ({companies.length})</h3>
+        {companies.length === 0 ? (
+          <div className="empty-state">
+            <p>{t('companies.noCompanies')}</p>
+            <p>{t('companies.createFirst')}</p>
+          </div>
+        ) : (
+          <div className="companies-grid">
+            {companies.map(company => (
+              <div key={company.companyId} className="company-card">
+                <h4>{company.name}</h4>
+                {company.abbreviation && (
+                  <span className="company-abbreviation">{company.abbreviation}</span>
+                )}
+                {company.description && (
+                  <p className="company-description">{company.description}</p>
+                )}
+                <div className="company-actions">
+                  <button
+                    onClick={() => handleEdit(company)}
+                    className="company-edit-btn"
+                  >
+                    {t('common.edit')}
+                  </button>
+                  <button
+                    onClick={() => handleDelete(company.companyId)}
+                    className="company-delete-btn"
+                    disabled={deleting === company.companyId}
+                  >
+                    {deleting === company.companyId ? t('common.saving') : t('common.delete')}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/ManageDivisions.css
+++ b/frontend/src/components/admin/ManageDivisions.css
@@ -68,6 +68,12 @@
   font-size: 1.25rem;
 }
 
+.division-company {
+  color: #999;
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+}
+
 .division-description {
   color: #bbb;
   margin-bottom: 1rem;

--- a/frontend/src/components/admin/ManageDivisions.tsx
+++ b/frontend/src/components/admin/ManageDivisions.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect, FormEvent } from 'react';
-import { divisionsApi } from '../../services/api';
-import type { Division } from '../../types';
+import { useTranslation } from 'react-i18next';
+import { divisionsApi, companiesApi } from '../../services/api';
+import type { Division, Company } from '../../types';
 import Skeleton from '../ui/Skeleton';
 import './ManageDivisions.css';
 
 export default function ManageDivisions() {
+  const { t } = useTranslation();
   const [divisions, setDivisions] = useState<Division[]>([]);
+  const [companies, setCompanies] = useState<Company[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -16,22 +19,33 @@ export default function ManageDivisions() {
   const [formData, setFormData] = useState({
     name: '',
     description: '',
+    companyId: '',
   });
 
   useEffect(() => {
-    loadDivisions();
+    loadData();
   }, []);
 
-  const loadDivisions = async () => {
+  const loadData = async () => {
     try {
       setLoading(true);
-      const data = await divisionsApi.getAll();
-      setDivisions(data);
+      const [divisionsData, companiesData] = await Promise.all([
+        divisionsApi.getAll(),
+        companiesApi.getAll(),
+      ]);
+      setDivisions(divisionsData);
+      setCompanies(companiesData);
     } catch (_err) {
       setError('Failed to load divisions');
     } finally {
       setLoading(false);
     }
+  };
+
+  const getCompanyName = (companyId?: string) => {
+    if (!companyId) return 'None';
+    const company = companies.find(c => c.companyId === companyId);
+    return company?.name || t('common.unknown');
   };
 
   const handleSubmit = async (e: FormEvent) => {
@@ -44,20 +58,22 @@ export default function ManageDivisions() {
         await divisionsApi.update(editingDivision.divisionId, {
           name: formData.name,
           description: formData.description || undefined,
+          companyId: formData.companyId || undefined,
         });
         setSuccess('Division updated successfully!');
       } else {
         await divisionsApi.create({
           name: formData.name,
           description: formData.description || undefined,
+          companyId: formData.companyId || undefined,
         });
         setSuccess('Division created successfully!');
       }
 
-      setFormData({ name: '', description: '' });
+      setFormData({ name: '', description: '', companyId: '' });
       setShowAddForm(false);
       setEditingDivision(null);
-      await loadDivisions();
+      await loadData();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save division');
     }
@@ -68,6 +84,7 @@ export default function ManageDivisions() {
     setFormData({
       name: division.name,
       description: division.description || '',
+      companyId: division.companyId || '',
     });
     setShowAddForm(true);
   };
@@ -84,7 +101,7 @@ export default function ManageDivisions() {
     try {
       await divisionsApi.delete(divisionId);
       setSuccess('Division deleted successfully!');
-      await loadDivisions();
+      await loadData();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete division');
     } finally {
@@ -93,7 +110,7 @@ export default function ManageDivisions() {
   };
 
   const handleCancel = () => {
-    setFormData({ name: '', description: '' });
+    setFormData({ name: '', description: '', companyId: '' });
     setShowAddForm(false);
     setEditingDivision(null);
   };
@@ -143,6 +160,22 @@ export default function ManageDivisions() {
               />
             </div>
 
+            <div className="form-group">
+              <label htmlFor="division-company">Company</label>
+              <select
+                id="division-company"
+                value={formData.companyId}
+                onChange={(e) => setFormData({ ...formData, companyId: e.target.value })}
+              >
+                <option value="">No Company</option>
+                {companies.map((company) => (
+                  <option key={company.companyId} value={company.companyId}>
+                    {company.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
             <div className="form-actions">
               <button type="submit">
                 {editingDivision ? 'Update Division' : 'Create Division'}
@@ -164,6 +197,9 @@ export default function ManageDivisions() {
             {divisions.map(division => (
               <div key={division.divisionId} className="division-card">
                 <h4>{division.name}</h4>
+                {division.companyId && (
+                  <p className="division-company">Company: {getCompanyName(division.companyId)}</p>
+                )}
                 {division.description && (
                   <p className="division-description">{division.description}</p>
                 )}

--- a/frontend/src/components/admin/ManageShows.css
+++ b/frontend/src/components/admin/ManageShows.css
@@ -1,0 +1,164 @@
+.manage-shows {
+  width: 100%;
+}
+
+.shows-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.show-form-container {
+  background-color: #1a1a1a;
+  border: 2px solid #d4af37;
+  border-radius: 8px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+
+.show-form-container h3 {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  color: #d4af37;
+}
+
+.show-form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.show-form textarea {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: #222;
+  border: 2px solid #444;
+  border-radius: 4px;
+  color: #fff;
+  font-family: inherit;
+  font-size: 1rem;
+  resize: vertical;
+}
+
+.show-form textarea:focus {
+  outline: none;
+  border-color: #d4af37;
+}
+
+.shows-list h3 {
+  margin-bottom: 1.5rem;
+}
+
+.company-shows-group {
+  margin-bottom: 2rem;
+}
+
+.company-group-title {
+  color: #d4af37;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #333;
+}
+
+.shows-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.show-card {
+  background-color: #1a1a1a;
+  border: 2px solid #d4af37;
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+
+.show-card h4 {
+  margin: 0 0 0.5rem 0;
+  color: #d4af37;
+  font-size: 1.25rem;
+}
+
+.show-meta {
+  margin-bottom: 0.75rem;
+}
+
+.show-schedule-badge {
+  display: inline-block;
+  background-color: #333;
+  color: #d4af37;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: bold;
+}
+
+.show-description {
+  color: #bbb;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.show-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #333;
+}
+
+.show-edit-btn {
+  background-color: #3b82f6;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  flex: 1;
+}
+
+.show-edit-btn:hover {
+  background-color: #2563eb;
+}
+
+.show-delete-btn {
+  background-color: #7f1d1d !important;
+  color: #fecaca;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  flex: 1;
+}
+
+.show-delete-btn:hover:not(:disabled) {
+  background-color: #991b1b !important;
+}
+
+.show-delete-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+  color: #888;
+}
+
+@media (max-width: 768px) {
+  .shows-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .show-form-container {
+    padding: 1rem;
+  }
+
+  .shows-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .show-card {
+    padding: 1rem;
+  }
+}

--- a/frontend/src/components/admin/ManageShows.tsx
+++ b/frontend/src/components/admin/ManageShows.tsx
@@ -1,0 +1,276 @@
+import { useState, useEffect, FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { showsApi, companiesApi } from '../../services/api';
+import type { Show, Company } from '../../types';
+import Skeleton from '../ui/Skeleton';
+import './ManageShows.css';
+
+export default function ManageShows() {
+  const { t } = useTranslation();
+  const [shows, setShows] = useState<Show[]>([]);
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [editingShow, setEditingShow] = useState<Show | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const [formData, setFormData] = useState({
+    name: '',
+    companyId: '',
+    schedule: '' as '' | 'weekly' | 'ppv' | 'special',
+    description: '',
+  });
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const loadData = async () => {
+    try {
+      setLoading(true);
+      const [showsData, companiesData] = await Promise.all([
+        showsApi.getAll(),
+        companiesApi.getAll(),
+      ]);
+      setShows(showsData);
+      setCompanies(companiesData);
+    } catch (_err) {
+      setError('Failed to load data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getCompanyName = (companyId: string) => {
+    const company = companies.find(c => c.companyId === companyId);
+    return company?.name || t('common.unknown');
+  };
+
+  const getScheduleLabel = (schedule?: string) => {
+    if (!schedule) return '-';
+    return t(`shows.${schedule}`);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    if (!formData.companyId) {
+      setError(t('shows.selectCompany'));
+      return;
+    }
+
+    try {
+      if (editingShow) {
+        await showsApi.update(editingShow.showId, {
+          name: formData.name,
+          companyId: formData.companyId,
+          schedule: formData.schedule || undefined,
+          description: formData.description || undefined,
+        });
+        setSuccess(t('shows.edit') + ' - OK');
+      } else {
+        await showsApi.create({
+          name: formData.name,
+          companyId: formData.companyId,
+          schedule: formData.schedule || undefined,
+          description: formData.description || undefined,
+        });
+        setSuccess(t('shows.create') + ' - OK');
+      }
+
+      setFormData({ name: '', companyId: '', schedule: '', description: '' });
+      setShowAddForm(false);
+      setEditingShow(null);
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save show');
+    }
+  };
+
+  const handleEdit = (show: Show) => {
+    setEditingShow(show);
+    setFormData({
+      name: show.name,
+      companyId: show.companyId,
+      schedule: show.schedule || '',
+      description: show.description || '',
+    });
+    setShowAddForm(true);
+  };
+
+  const handleDelete = async (showId: string) => {
+    if (!confirm(t('shows.confirmDelete'))) {
+      return;
+    }
+
+    setDeleting(showId);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      await showsApi.delete(showId);
+      setSuccess(t('shows.delete') + ' - OK');
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete show');
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const handleCancel = () => {
+    setFormData({ name: '', companyId: '', schedule: '', description: '' });
+    setShowAddForm(false);
+    setEditingShow(null);
+  };
+
+  // Group shows by company
+  const showsByCompany = shows.reduce<Record<string, Show[]>>((acc, show) => {
+    const key = show.companyId;
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(show);
+    return acc;
+  }, {});
+
+  if (loading) {
+    return <Skeleton variant="block" count={4} />;
+  }
+
+  return (
+    <div className="manage-shows">
+      <div className="shows-header">
+        <h2>{t('shows.title')}</h2>
+        {!showAddForm && (
+          <button onClick={() => setShowAddForm(true)}>
+            {t('shows.create')}
+          </button>
+        )}
+      </div>
+
+      {error && <div className="error-message">{error}</div>}
+      {success && <div className="success-message">{success}</div>}
+
+      {showAddForm && (
+        <div className="show-form-container">
+          <h3>{editingShow ? t('shows.edit') : t('shows.create')}</h3>
+          <form onSubmit={handleSubmit} className="show-form">
+            <div className="form-group">
+              <label htmlFor="show-name">{t('shows.name')}</label>
+              <input
+                type="text"
+                id="show-name"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                required
+                placeholder="e.g., Monday Night Raw, Dynamite"
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="show-company">{t('shows.company')}</label>
+              <select
+                id="show-company"
+                value={formData.companyId}
+                onChange={(e) => setFormData({ ...formData, companyId: e.target.value })}
+                required
+              >
+                <option value="">{t('shows.selectCompany')}</option>
+                {companies.map((company) => (
+                  <option key={company.companyId} value={company.companyId}>
+                    {company.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="show-schedule">{t('shows.schedule')}</label>
+              <select
+                id="show-schedule"
+                value={formData.schedule}
+                onChange={(e) => setFormData({ ...formData, schedule: e.target.value as '' | 'weekly' | 'ppv' | 'special' })}
+              >
+                <option value="">-</option>
+                <option value="weekly">{t('shows.weekly')}</option>
+                <option value="ppv">{t('shows.ppv')}</option>
+                <option value="special">{t('shows.special')}</option>
+              </select>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="show-description">{t('shows.description')}</label>
+              <textarea
+                id="show-description"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                placeholder="Brief description of this show"
+                rows={3}
+              />
+            </div>
+
+            <div className="form-actions">
+              <button type="submit">
+                {editingShow ? t('shows.edit') : t('shows.create')}
+              </button>
+              <button type="button" onClick={handleCancel} className="cancel-btn">
+                {t('common.cancel')}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      <div className="shows-list">
+        <h3>{t('shows.title')} ({shows.length})</h3>
+        {shows.length === 0 ? (
+          <div className="empty-state">
+            <p>{t('shows.noShows')}</p>
+            <p>{t('shows.createFirst')}</p>
+          </div>
+        ) : (
+          <div className="shows-by-company">
+            {Object.entries(showsByCompany).map(([companyId, companyShows]) => (
+              <div key={companyId} className="company-shows-group">
+                <h4 className="company-group-title">{getCompanyName(companyId)}</h4>
+                <div className="shows-grid">
+                  {companyShows.map(show => (
+                    <div key={show.showId} className="show-card">
+                      <h4>{show.name}</h4>
+                      <div className="show-meta">
+                        <span className="show-schedule-badge">
+                          {getScheduleLabel(show.schedule)}
+                        </span>
+                      </div>
+                      {show.description && (
+                        <p className="show-description">{show.description}</p>
+                      )}
+                      <div className="show-actions">
+                        <button
+                          onClick={() => handleEdit(show)}
+                          className="show-edit-btn"
+                        >
+                          {t('common.edit')}
+                        </button>
+                        <button
+                          onClick={() => handleDelete(show.showId)}
+                          className="show-delete-btn"
+                          disabled={deleting === show.showId}
+                        >
+                          {deleting === show.showId ? t('common.saving') : t('common.delete')}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/ManageWrestlers.tsx
+++ b/frontend/src/components/admin/ManageWrestlers.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, FormEvent, ChangeEvent } from 'react';
 import { Link } from 'react-router-dom';
-import { wrestlersApi, imagesApi, divisionsApi } from '../../services/api';
+import { wrestlersApi, imagesApi, divisionsApi, companiesApi } from '../../services/api';
 import { sanitizeName } from '../../utils/sanitize';
 import { logger } from '../../utils/logger';
 import { FILE_UPLOAD_LIMITS, VALIDATION } from '../../constants';
@@ -9,12 +9,13 @@ import {
   applyImageFallback,
   resolveImageSrc,
 } from '../../constants/imageFallbacks';
-import type { Wrestler, Division } from '../../types';
+import type { Wrestler, Division, Company } from '../../types';
 import './ManageWrestlers.css';
 
 export default function ManageWrestlers() {
   const [wrestlers, setWrestlers] = useState<Wrestler[]>([]);
   const [divisions, setDivisions] = useState<Division[]>([]);
+  const [companies, setCompanies] = useState<Company[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
@@ -29,6 +30,7 @@ export default function ManageWrestlers() {
     name: '',
     imageUrl: '',
     divisionId: '',
+    companyId: '',
   });
 
   // Image upload state
@@ -42,12 +44,14 @@ export default function ManageWrestlers() {
   const loadData = async () => {
     try {
       setLoading(true);
-      const [wrestlersData, divisionsData] = await Promise.all([
+      const [wrestlersData, divisionsData, companiesData] = await Promise.all([
         wrestlersApi.getAll(),
         divisionsApi.getAll(),
+        companiesApi.getAll(),
       ]);
       setWrestlers(wrestlersData);
       setDivisions(divisionsData);
+      setCompanies(companiesData);
     } catch (_err) {
       setError('Failed to load data');
     } finally {
@@ -59,6 +63,12 @@ export default function ManageWrestlers() {
     if (!divisionId) return 'None';
     const division = divisions.find(d => d.divisionId === divisionId);
     return division?.name || 'Unknown';
+  };
+
+  const getCompanyName = (companyId?: string) => {
+    if (!companyId) return 'None';
+    const company = companies.find(c => c.companyId === companyId);
+    return company?.name || 'Unknown';
   };
 
   const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
@@ -160,19 +170,21 @@ export default function ManageWrestlers() {
           name: sanitizedName,
           imageUrl: imageUrl || undefined,
           divisionId: formData.divisionId || undefined,
+          companyId: formData.companyId || undefined,
         });
       } else {
         await wrestlersApi.create({
           name: sanitizedName,
           imageUrl: imageUrl || undefined,
           divisionId: formData.divisionId || undefined,
+          companyId: formData.companyId || undefined,
           wins: 0,
           losses: 0,
           draws: 0,
         });
       }
 
-      setFormData({ name: '', imageUrl: '', divisionId: '' });
+      setFormData({ name: '', imageUrl: '', divisionId: '', companyId: '' });
       setSelectedFile(null);
       setImagePreview(null);
       setShowAddForm(false);
@@ -192,6 +204,7 @@ export default function ManageWrestlers() {
       name: wrestler.name,
       imageUrl: wrestler.imageUrl || '',
       divisionId: wrestler.divisionId || '',
+      companyId: wrestler.companyId || '',
     });
     setImagePreview(wrestler.imageUrl || null);
     setSelectedFile(null);
@@ -199,7 +212,7 @@ export default function ManageWrestlers() {
   };
 
   const handleCancel = () => {
-    setFormData({ name: '', imageUrl: '', divisionId: '' });
+    setFormData({ name: '', imageUrl: '', divisionId: '', companyId: '' });
     setSelectedFile(null);
     setImagePreview(null);
     setShowAddForm(false);
@@ -278,6 +291,22 @@ export default function ManageWrestlers() {
             </div>
 
             <div className="form-group">
+              <label htmlFor="company">Company</label>
+              <select
+                id="company"
+                value={formData.companyId}
+                onChange={(e) => setFormData({ ...formData, companyId: e.target.value })}
+              >
+                <option value="">No Company</option>
+                {companies.map((company) => (
+                  <option key={company.companyId} value={company.companyId}>
+                    {company.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="form-group">
               <label htmlFor="image">Wrestler Image</label>
               <div className="image-upload-container">
                 {imagePreview ? (
@@ -328,6 +357,7 @@ export default function ManageWrestlers() {
               <tr>
                 <th>Image</th>
                 <th>Wrestler Name</th>
+                <th>Company</th>
                 <th>Division</th>
                 <th>Record</th>
                 <th>Actions</th>
@@ -345,6 +375,7 @@ export default function ManageWrestlers() {
                     />
                   </td>
                   <td>{wrestler.name}</td>
+                  <td className="company-cell">{getCompanyName(wrestler.companyId)}</td>
                   <td className="division-cell">{getDivisionName(wrestler.divisionId)}</td>
                   <td>
                     <span className="record">

--- a/frontend/src/components/admin/ScheduleMatch.tsx
+++ b/frontend/src/components/admin/ScheduleMatch.tsx
@@ -77,6 +77,13 @@ export default function ScheduleMatch() {
 
   const isTagTeamMatch = formData.matchFormat.toLowerCase().includes('tag');
 
+  // Filter wrestlers by event's hosting companies
+  const selectedEvent = events.find(ev => ev.eventId === formData.eventId);
+  const eventCompanyIds = selectedEvent?.companyIds;
+  const filteredWrestlers = (eventCompanyIds && eventCompanyIds.length > 0)
+    ? wrestlers.filter(w => !w.companyId || eventCompanyIds.includes(w.companyId))
+    : wrestlers;
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (submitting) return; // Prevent double submission
@@ -315,7 +322,10 @@ export default function ScheduleMatch() {
             <SearchableSelect
               id="event"
               value={formData.eventId}
-              onChange={(value) => setFormData({ ...formData, eventId: value })}
+              onChange={(value) => {
+                setFormData({ ...formData, eventId: value, participants: [] });
+                setTeams([[], []]);
+              }}
               placeholder={t('scheduleMatch.noEvent', 'No Event (Standalone Match)')}
               options={[
                 { value: '', label: t('scheduleMatch.noEvent', 'No Event (Standalone Match)') },
@@ -432,7 +442,7 @@ export default function ScheduleMatch() {
                     )}
                   </div>
                   <div className="team-wrestlers-grid">
-                    {wrestlers.filter(p => !team.includes(p.wrestlerId)).map(wrestler => {
+                    {filteredWrestlers.filter(p => !team.includes(p.wrestlerId)).map(wrestler => {
                       const wrestlerTeamIndex = getWrestlerTeamIndex(wrestler.wrestlerId);
                       const isInOtherTeam = wrestlerTeamIndex !== -1 && wrestlerTeamIndex !== teamIndex;
                       return (
@@ -471,7 +481,7 @@ export default function ScheduleMatch() {
           <div className="form-group">
             <label>{t('scheduleMatch.participants')} ({formData.matchFormat.toLowerCase() === 'singles' ? '2' : '2+'})</label>
             <div className="participants-grid">
-              {wrestlers.map(wrestler => (
+              {filteredWrestlers.map(wrestler => (
                 <div
                   key={wrestler.wrestlerId}
                   className={`participant-card ${formData.participants.includes(wrestler.wrestlerId) ? 'selected' : ''}`}

--- a/frontend/src/components/admin/__tests__/CreateEvent.test.tsx
+++ b/frontend/src/components/admin/__tests__/CreateEvent.test.tsx
@@ -19,6 +19,9 @@ vi.mock('../../../services/api', () => ({
   seasonsApi: {
     getAll: mockGetAllSeasons,
   },
+  companiesApi: {
+    getAll: vi.fn().mockResolvedValue([]),
+  },
 }));
 
 vi.mock('react-i18next', () => ({

--- a/frontend/src/components/admin/__tests__/ManageDivisions.test.tsx
+++ b/frontend/src/components/admin/__tests__/ManageDivisions.test.tsx
@@ -14,6 +14,9 @@ const { mockDivisionsApi } = vi.hoisted(() => ({
 
 vi.mock('../../../services/api', () => ({
   divisionsApi: mockDivisionsApi,
+  companiesApi: {
+    getAll: vi.fn().mockResolvedValue([]),
+  },
 }));
 
 vi.mock('../ManageDivisions.css', () => ({}));

--- a/frontend/src/components/admin/__tests__/ManageWrestlers.test.tsx
+++ b/frontend/src/components/admin/__tests__/ManageWrestlers.test.tsx
@@ -19,6 +19,9 @@ vi.mock('../../../services/api', () => ({
   wrestlersApi: mockWrestlersApi,
   divisionsApi: mockDivisionsApi,
   imagesApi: mockImagesApi,
+  companiesApi: {
+    getAll: vi.fn().mockResolvedValue([]),
+  },
 }));
 
 import ManageWrestlers from '../ManageWrestlers';

--- a/frontend/src/config/navConfig.ts
+++ b/frontend/src/config/navConfig.ts
@@ -64,6 +64,8 @@ export const ADMIN_NAV_GROUPS: NavGroup[] = [
     i18nKey: 'admin.panel.groups.leagueSetup',
     items: [
       { path: '/admin/wrestlers', i18nKey: 'admin.panel.tabs.manageWrestlers' },
+      { path: '/admin/companies', i18nKey: 'admin.panel.tabs.companies' },
+      { path: '/admin/shows', i18nKey: 'admin.panel.tabs.shows' },
       { path: '/admin/divisions', i18nKey: 'admin.panel.tabs.divisions' },
       { path: '/admin/seasons', i18nKey: 'admin.panel.tabs.seasons' },
       { path: '/admin/season-awards', i18nKey: 'admin.panel.tabs.seasonAwards' },
@@ -98,7 +100,7 @@ export function getUserGroupForPath(pathname: string): string | null {
 /** Path -> admin group key */
 export function getAdminGroupForPath(pathname: string): string | null {
   const matchOps = ['/admin/schedule', '/admin/results', '/admin/events', '/admin/match-config'];
-  const leagueSetup = ['/admin/wrestlers', '/admin/divisions', '/admin/seasons', '/admin/season-awards', '/admin/championships', '/admin/tournaments'];
+  const leagueSetup = ['/admin/wrestlers', '/admin/companies', '/admin/shows', '/admin/divisions', '/admin/seasons', '/admin/season-awards', '/admin/championships', '/admin/tournaments'];
   const contentSocial = ['/admin/contender-config'];
   const system = ['/admin/features', '/admin/danger'];
   if (matchOps.some((p) => pathname === p)) return 'matchOps';

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -350,11 +350,44 @@
       "points": "Punkte"
     }
   },
+  "companies": {
+    "title": "Companies",
+    "name": "Company-Name",
+    "abbreviation": "Abkürzung",
+    "description": "Beschreibung",
+    "create": "Company erstellen",
+    "edit": "Company bearbeiten",
+    "delete": "Company löschen",
+    "noCompanies": "Noch keine Companies",
+    "createFirst": "Erstelle deine erste Company, um loszulegen",
+    "confirmDelete": "Möchtest du diese Company wirklich löschen?",
+    "rosterCount": "Kader",
+    "deleteBlocked": "Company mit zugewiesenen Wrestlern oder Shows kann nicht gelöscht werden"
+  },
+  "shows": {
+    "title": "Shows",
+    "name": "Show-Name",
+    "company": "Company",
+    "schedule": "Zeitplan",
+    "description": "Beschreibung",
+    "weekly": "Wöchentlich",
+    "ppv": "PPV",
+    "special": "Spezial",
+    "create": "Show erstellen",
+    "edit": "Show bearbeiten",
+    "delete": "Show löschen",
+    "noShows": "Noch keine Shows",
+    "createFirst": "Erstelle deine erste Show, um loszulegen",
+    "confirmDelete": "Möchtest du diese Show wirklich löschen?",
+    "selectCompany": "Company auswählen"
+  },
   "admin": {
     "panel": {
       "title": "Admin-Bereich",
       "tabs": {
         "manageWrestlers": "Wrestler verwalten",
+        "companies": "Companies",
+        "shows": "Shows",
         "divisions": "Divisionen",
         "stipulations": "Stipulationen",
         "matchConfig": "Match-Konfiguration",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -350,11 +350,44 @@
       "points": "Points"
     }
   },
+  "companies": {
+    "title": "Companies",
+    "name": "Company Name",
+    "abbreviation": "Abbreviation",
+    "description": "Description",
+    "create": "Create Company",
+    "edit": "Edit Company",
+    "delete": "Delete Company",
+    "noCompanies": "No companies yet",
+    "createFirst": "Create your first company to get started",
+    "confirmDelete": "Are you sure you want to delete this company?",
+    "rosterCount": "Roster",
+    "deleteBlocked": "Cannot delete company with assigned wrestlers or shows"
+  },
+  "shows": {
+    "title": "Shows",
+    "name": "Show Name",
+    "company": "Company",
+    "schedule": "Schedule",
+    "description": "Description",
+    "weekly": "Weekly",
+    "ppv": "PPV",
+    "special": "Special",
+    "create": "Create Show",
+    "edit": "Edit Show",
+    "delete": "Delete Show",
+    "noShows": "No shows yet",
+    "createFirst": "Create your first show to get started",
+    "confirmDelete": "Are you sure you want to delete this show?",
+    "selectCompany": "Select a company"
+  },
   "admin": {
     "panel": {
       "title": "Admin Panel",
       "tabs": {
         "manageWrestlers": "Manage Wrestlers",
+        "companies": "Companies",
+        "shows": "Shows",
         "divisions": "Divisions",
         "stipulations": "Stipulations",
         "matchConfig": "Match Config",

--- a/frontend/src/services/api/companies.api.ts
+++ b/frontend/src/services/api/companies.api.ts
@@ -1,0 +1,28 @@
+import type { Company } from '../../types';
+import { createCrudApi } from './crudFactory';
+
+const baseCrud = createCrudApi<Company, { name: string; abbreviation?: string; description?: string; imageUrl?: string }>('companies');
+
+export const companiesApi = {
+  getAll: async (signal?: AbortSignal): Promise<Company[]> => {
+    return baseCrud.getAll(signal);
+  },
+
+  getById: async (companyId: string): Promise<Company> => {
+    // crudFactory doesn't have getById, use fetchWithAuth directly
+    const { API_BASE_URL, fetchWithAuth } = await import('./apiClient');
+    return fetchWithAuth(`${API_BASE_URL}/companies/${companyId}`);
+  },
+
+  create: async (company: { name: string; abbreviation?: string; description?: string; imageUrl?: string }): Promise<Company> => {
+    return baseCrud.create(company);
+  },
+
+  update: async (companyId: string, updates: Partial<Company>): Promise<Company> => {
+    return baseCrud.updateById(companyId, updates);
+  },
+
+  delete: async (companyId: string): Promise<void> => {
+    return baseCrud.deleteById(companyId);
+  },
+};

--- a/frontend/src/services/api/divisions.api.ts
+++ b/frontend/src/services/api/divisions.api.ts
@@ -1,14 +1,14 @@
 import type { Division } from '../../types';
 import { createCrudApi } from './crudFactory';
 
-const baseDivisionsApi = createCrudApi<Division, { name: string; description?: string }>('divisions');
+const baseDivisionsApi = createCrudApi<Division, { name: string; description?: string; companyId?: string }>('divisions');
 
 export const divisionsApi = {
   getAll: async (signal?: AbortSignal): Promise<Division[]> => {
     return baseDivisionsApi.getAll(signal);
   },
 
-  create: async (division: { name: string; description?: string }): Promise<Division> => {
+  create: async (division: { name: string; description?: string; companyId?: string }): Promise<Division> => {
     return baseDivisionsApi.create(division);
   },
 

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -22,6 +22,8 @@ export { rivalriesApi } from './rivalries.api';
 export { imagesApi } from './images.api';
 export { activityApi } from './activity.api';
 export { seasonAwardsApi } from './seasonAwards.api';
+export { companiesApi } from './companies.api';
+export { showsApi } from './shows.api';
 
 // Type/interface re-exports
 export type { SiteFeatures } from './siteConfig.api';

--- a/frontend/src/services/api/shows.api.ts
+++ b/frontend/src/services/api/shows.api.ts
@@ -1,0 +1,35 @@
+import type { Show } from '../../types';
+import { API_BASE_URL, fetchWithAuth } from './apiClient';
+
+export const showsApi = {
+  getAll: async (filters?: { companyId?: string }, signal?: AbortSignal): Promise<Show[]> => {
+    const params = new URLSearchParams();
+    if (filters?.companyId) params.set('companyId', filters.companyId);
+    const query = params.toString();
+    return fetchWithAuth(`${API_BASE_URL}/shows${query ? `?${query}` : ''}`, {}, signal);
+  },
+
+  getById: async (showId: string): Promise<Show> => {
+    return fetchWithAuth(`${API_BASE_URL}/shows/${showId}`);
+  },
+
+  create: async (show: { name: string; companyId: string; description?: string; schedule?: 'weekly' | 'ppv' | 'special' }): Promise<Show> => {
+    return fetchWithAuth(`${API_BASE_URL}/shows`, {
+      method: 'POST',
+      body: JSON.stringify(show),
+    });
+  },
+
+  update: async (showId: string, updates: Partial<Show>): Promise<Show> => {
+    return fetchWithAuth(`${API_BASE_URL}/shows/${showId}`, {
+      method: 'PUT',
+      body: JSON.stringify(updates),
+    });
+  },
+
+  delete: async (showId: string): Promise<void> => {
+    return fetchWithAuth(`${API_BASE_URL}/shows/${showId}`, {
+      method: 'DELETE',
+    });
+  },
+};

--- a/frontend/src/types/event.ts
+++ b/frontend/src/types/event.ts
@@ -22,6 +22,8 @@ export interface LeagueEvent {
   themeColor?: string;
   status: EventStatus;
   seasonId?: string;
+  companyIds?: string[];
+  showId?: string;
   matchCards: MatchCardEntry[];
   attendance?: number;
   rating?: number;
@@ -77,6 +79,8 @@ export interface CreateEventInput {
   imageUrl?: string;
   themeColor?: string;
   seasonId?: string;
+  companyIds?: string[];
+  showId?: string;
   fantasyEnabled?: boolean;
   fantasyBudget?: number;
   fantasyPicksPerDivision?: number;
@@ -88,6 +92,8 @@ export interface UpdateEventInput extends Partial<CreateEventInput> {
   matchCards?: MatchCardEntry[];
   attendance?: number;
   rating?: number;
+  companyIds?: string[];
+  showId?: string;
   fantasyEnabled?: boolean;
   fantasyLocked?: boolean;
   fantasyBudget?: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,6 +12,7 @@ export interface Wrestler {
   draws: number;
   imageUrl?: string;
   divisionId?: string;
+  companyId?: string;
   createdAt: string;
   updatedAt: string;
   /** Last 5 match results (newest first): W win, L loss, D draw */
@@ -63,6 +64,7 @@ export interface Championship {
   type: 'singles' | 'tag';
   currentChampion?: string | string[]; // wrestlerId or array for tag teams
   divisionId?: string;
+  companyId?: string;
   imageUrl?: string;
   createdAt: string;
   isActive: boolean;
@@ -195,6 +197,27 @@ export interface Division {
   divisionId: string;
   name: string;
   description?: string;
+  companyId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Company {
+  companyId: string;
+  name: string;
+  abbreviation?: string;
+  imageUrl?: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Show {
+  showId: string;
+  name: string;
+  companyId: string;
+  description?: string;
+  schedule?: 'weekly' | 'ppv' | 'special';
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- New **Companies** entity with full CRUD (backend Lambda + DynamoDB + frontend admin UI)
- New **Shows** entity with full CRUD, each show belongs to a company (CompanyShowsIndex GSI)
- **CompanyIndex GSI** on WrestlersTable for querying company rosters
- Wrestlers, Championships, and Divisions gain optional `companyId` field
- Events gain `companyIds` array for multi-company hosting and `showId` for show association
- **Roster-based match booking**: when scheduling matches on an event, backend validates wrestlers belong to hosting companies; frontend filters wrestler picker accordingly
- Seed data includes 3 sample companies (WWF, WCW, ECW) and 3 shows (Raw, Nitro, ECW Hardcore TV)
- i18n translations for companies and shows in English and German

## Test plan
- [x] Backend TypeScript compilation passes
- [x] Frontend TypeScript compilation passes
- [x] Backend tests pass (58 files, 641 tests)
- [x] Frontend tests pass (46 files, 307 tests)
- [x] New Companies CRUD: 23 tests + 6 handler routing tests
- [x] New Shows CRUD: 26 tests + 6 handler routing tests
- [ ] Manual: Create company, assign wrestlers, create show, create event with companyIds, verify roster filtering in match scheduling

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)