### PR TITLE
feat: bulk import wrestlers via CSV/JSON upload (#5)

### DIFF
--- a/backend/functions/wrestlers/__tests__/importWrestlers.test.ts
+++ b/backend/functions/wrestlers/__tests__/importWrestlers.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+// ---- Mocks ----------------------------------------------------------------
+
+const { mockGet, mockPut, mockBatchWrite } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPut: vi.fn(),
+  mockBatchWrite: vi.fn(),
+}));
+
+vi.mock('../../../lib/dynamodb', () => ({
+  dynamoDb: {
+    get: mockGet,
+    put: mockPut,
+    scan: vi.fn(),
+    query: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    scanAll: vi.fn(),
+    queryAll: vi.fn(),
+    transactWrite: vi.fn(),
+    batchWrite: mockBatchWrite,
+  },
+  TableNames: {
+    MATCHES: 'Matches',
+    WRESTLERS: 'Wrestlers',
+    CHAMPIONSHIPS: 'Championships',
+    TOURNAMENTS: 'Tournaments',
+    SEASONS: 'Seasons',
+    EVENTS: 'Events',
+    STIPULATIONS: 'Stipulations',
+    COMPANIES: 'Companies',
+    SHOWS: 'Shows',
+  },
+}));
+
+vi.mock('uuid', () => ({
+  v4: () => 'test-uuid',
+}));
+
+import { handler as importWrestlers } from '../importWrestlers';
+
+// ---- Helpers ---------------------------------------------------------------
+
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+function ev(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+  return {
+    body: null, headers: {}, multiValueHeaders: {}, httpMethod: 'POST',
+    isBase64Encoded: false, path: '/', pathParameters: null,
+    queryStringParameters: null, multiValueQueryStringParameters: null,
+    stageVariables: null, resource: '', requestContext: { authorizer: {} } as unknown as APIGatewayProxyEvent['requestContext'],
+    ...overrides,
+  };
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+describe('importWrestlers', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('imports valid wrestlers and returns 201', async () => {
+    mockBatchWrite.mockResolvedValue(undefined);
+    const body = JSON.stringify({
+      wrestlers: [
+        { name: 'Stone Cold Steve Austin', alignment: 'face' },
+        { name: 'The Rock', alignment: 'heel' },
+      ],
+    });
+
+    const r = await importWrestlers(ev({ body }), ctx, cb);
+    expect(r!.statusCode).toBe(201);
+
+    const b = JSON.parse(r!.body);
+    expect(b.imported).toBe(2);
+    expect(b.failed).toBe(0);
+    expect(b.total).toBe(2);
+    expect(b.errors).toEqual([]);
+    expect(mockBatchWrite).toHaveBeenCalledOnce();
+    expect(mockBatchWrite).toHaveBeenCalledWith('Wrestlers', expect.arrayContaining([
+      expect.objectContaining({ name: 'Stone Cold Steve Austin', alignment: 'face', wins: 0, losses: 0, draws: 0 }),
+      expect.objectContaining({ name: 'The Rock', alignment: 'heel' }),
+    ]));
+  });
+
+  it('returns 400 when body is null', async () => {
+    const r = await importWrestlers(ev({ body: null }), ctx, cb);
+    expect(r!.statusCode).toBe(400);
+    expect(JSON.parse(r!.body).message).toBe('Request body is required');
+  });
+
+  it('returns 400 when wrestlers is not an array', async () => {
+    const r = await importWrestlers(ev({ body: JSON.stringify({ wrestlers: 'not-array' }) }), ctx, cb);
+    expect(r!.statusCode).toBe(400);
+    expect(JSON.parse(r!.body).message).toContain('must be an array');
+  });
+
+  it('returns 400 when wrestlers array is empty', async () => {
+    const r = await importWrestlers(ev({ body: JSON.stringify({ wrestlers: [] }) }), ctx, cb);
+    expect(r!.statusCode).toBe(400);
+    expect(JSON.parse(r!.body).message).toContain('must not be empty');
+  });
+
+  it('returns 400 when wrestlers exceeds 500', async () => {
+    const wrestlers = Array(501).fill({ name: 'x' }) as Array<{ name: string }>;
+    const r = await importWrestlers(ev({ body: JSON.stringify({ wrestlers }) }), ctx, cb);
+    expect(r!.statusCode).toBe(400);
+    expect(JSON.parse(r!.body).message).toContain('must not exceed 500');
+  });
+
+  it('handles wrestlers with missing name as partial failure', async () => {
+    mockBatchWrite.mockResolvedValue(undefined);
+    const body = JSON.stringify({
+      wrestlers: [
+        { name: 'Valid Wrestler' },
+        { name: '' },
+        { name: 'Another Valid' },
+        {},
+      ],
+    });
+
+    const r = await importWrestlers(ev({ body }), ctx, cb);
+    expect(r!.statusCode).toBe(201);
+
+    const b = JSON.parse(r!.body);
+    expect(b.imported).toBe(2);
+    expect(b.failed).toBe(2);
+    expect(b.total).toBe(4);
+    expect(b.errors).toHaveLength(2);
+    expect(b.errors[0].index).toBe(1);
+    expect(b.errors[0].reason).toContain('Name is required');
+    expect(b.errors[1].index).toBe(3);
+  });
+
+  it('handles duplicate names in batch as errors', async () => {
+    mockBatchWrite.mockResolvedValue(undefined);
+    const body = JSON.stringify({
+      wrestlers: [
+        { name: 'John Cena' },
+        { name: 'john cena' },
+        { name: 'The Undertaker' },
+      ],
+    });
+
+    const r = await importWrestlers(ev({ body }), ctx, cb);
+    expect(r!.statusCode).toBe(201);
+
+    const b = JSON.parse(r!.body);
+    expect(b.imported).toBe(2);
+    expect(b.failed).toBe(1);
+    expect(b.errors).toHaveLength(1);
+    expect(b.errors[0].index).toBe(1);
+    expect(b.errors[0].name).toBe('john cena');
+    expect(b.errors[0].reason).toContain('Duplicate name');
+  });
+
+  it('handles invalid alignment as error', async () => {
+    mockBatchWrite.mockResolvedValue(undefined);
+    const body = JSON.stringify({
+      wrestlers: [
+        { name: 'Good Wrestler', alignment: 'face' },
+        { name: 'Bad Alignment', alignment: 'badvalue' },
+      ],
+    });
+
+    const r = await importWrestlers(ev({ body }), ctx, cb);
+    expect(r!.statusCode).toBe(201);
+
+    const b = JSON.parse(r!.body);
+    expect(b.imported).toBe(1);
+    expect(b.failed).toBe(1);
+    expect(b.errors[0].index).toBe(1);
+    expect(b.errors[0].name).toBe('Bad Alignment');
+    expect(b.errors[0].reason).toContain('Invalid alignment');
+  });
+
+  it('validates companyId exists when provided', async () => {
+    mockGet.mockResolvedValue({ Item: { companyId: 'comp-1', name: 'WWE' } });
+    mockBatchWrite.mockResolvedValue(undefined);
+    const body = JSON.stringify({
+      wrestlers: [{ name: 'Test Wrestler' }],
+      companyId: 'comp-1',
+    });
+
+    const r = await importWrestlers(ev({ body }), ctx, cb);
+    expect(r!.statusCode).toBe(201);
+
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.objectContaining({ TableName: 'Companies', Key: { companyId: 'comp-1' } })
+    );
+    expect(mockBatchWrite).toHaveBeenCalledWith('Wrestlers', [
+      expect.objectContaining({ companyId: 'comp-1', name: 'Test Wrestler' }),
+    ]);
+  });
+
+  it('returns 404 when companyId does not exist', async () => {
+    mockGet.mockResolvedValue({ Item: undefined });
+    const body = JSON.stringify({
+      wrestlers: [{ name: 'Test Wrestler' }],
+      companyId: 'nonexistent',
+    });
+
+    const r = await importWrestlers(ev({ body }), ctx, cb);
+    expect(r!.statusCode).toBe(404);
+    expect(JSON.parse(r!.body).message).toContain('Company not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockBatchWrite.mockRejectedValue(new Error('DynamoDB failure'));
+    const body = JSON.stringify({
+      wrestlers: [{ name: 'Test Wrestler' }],
+    });
+
+    const r = await importWrestlers(ev({ body }), ctx, cb);
+    expect(r!.statusCode).toBe(500);
+    expect(JSON.parse(r!.body).message).toBe('Failed to import wrestlers');
+  });
+});

--- a/backend/functions/wrestlers/handler.ts
+++ b/backend/functions/wrestlers/handler.ts
@@ -2,6 +2,7 @@ import { handler as getWrestlersHandler } from './getWrestlers';
 import { handler as createWrestlerHandler } from './createWrestler';
 import { handler as updateWrestlerHandler } from './updateWrestler';
 import { handler as deleteWrestlerHandler } from './deleteWrestler';
+import { handler as importWrestlersHandler } from './importWrestlers';
 import { createRouter, type RouteConfig } from '../../lib/router';
 import { handler as getWrestlerStatisticsHandler } from './getWrestlerStatistics';
 
@@ -16,6 +17,11 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/wrestlers',
     method: 'GET',
     handler: getWrestlersHandler,
+  },
+  {
+    resource: '/wrestlers/import',
+    method: 'POST',
+    handler: importWrestlersHandler,
   },
   {
     resource: '/wrestlers',

--- a/backend/functions/wrestlers/importWrestlers.ts
+++ b/backend/functions/wrestlers/importWrestlers.ts
@@ -1,0 +1,139 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { v4 as uuidv4 } from 'uuid';
+import { parseBody } from '../../lib/parseBody';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { created, badRequest, notFound, serverError } from '../../lib/response';
+
+interface WrestlerImport {
+  name: string;
+  nickname?: string;
+  finisher?: string;
+  weight?: string;
+  height?: string;
+  hometown?: string;
+  alignment?: string;
+  imageUrl?: string;
+}
+
+interface ImportWrestlersBody {
+  wrestlers: WrestlerImport[];
+  companyId?: string;
+}
+
+interface ImportError {
+  index: number;
+  name: string;
+  reason: string;
+}
+
+const VALID_ALIGNMENTS = ['face', 'heel', 'tweener'];
+const MAX_WRESTLERS = 500;
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const parsed = parseBody<ImportWrestlersBody>(event);
+    if (parsed.error) {
+      return parsed.error;
+    }
+
+    const { wrestlers, companyId } = parsed.data;
+
+    // Validate wrestlers array
+    if (!Array.isArray(wrestlers)) {
+      return badRequest('wrestlers must be an array');
+    }
+
+    if (wrestlers.length === 0) {
+      return badRequest('wrestlers array must not be empty');
+    }
+
+    if (wrestlers.length > MAX_WRESTLERS) {
+      return badRequest(`wrestlers array must not exceed ${MAX_WRESTLERS} items`);
+    }
+
+    // If companyId provided, verify company exists
+    if (companyId) {
+      const companyResult = await dynamoDb.get({
+        TableName: TableNames.COMPANIES,
+        Key: { companyId },
+      });
+
+      if (!companyResult.Item) {
+        return notFound(`Company not found: ${companyId}`);
+      }
+    }
+
+    const errors: ImportError[] = [];
+    const validItems: Record<string, unknown>[] = [];
+    const seenNames = new Set<string>();
+    const now = new Date().toISOString();
+
+    for (let index = 0; index < wrestlers.length; index++) {
+      const wrestler = wrestlers[index];
+      const rawName = wrestler.name;
+
+      // Validate name
+      if (!rawName || typeof rawName !== 'string' || rawName.trim().length === 0) {
+        errors.push({ index, name: rawName || '', reason: 'Name is required' });
+        continue;
+      }
+
+      const trimmedName = rawName.trim();
+      const lowerName = trimmedName.toLowerCase();
+
+      // Check for duplicate names within batch
+      if (seenNames.has(lowerName)) {
+        errors.push({ index, name: trimmedName, reason: 'Duplicate name in batch' });
+        continue;
+      }
+
+      // Validate alignment if provided
+      if (wrestler.alignment && !VALID_ALIGNMENTS.includes(wrestler.alignment)) {
+        errors.push({
+          index,
+          name: trimmedName,
+          reason: `Invalid alignment: ${wrestler.alignment}. Must be face, heel, or tweener`,
+        });
+        continue;
+      }
+
+      seenNames.add(lowerName);
+
+      const item: Record<string, unknown> = {
+        wrestlerId: uuidv4(),
+        name: trimmedName,
+        wins: 0,
+        losses: 0,
+        draws: 0,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      if (wrestler.nickname) item.nickname = wrestler.nickname;
+      if (wrestler.finisher) item.finisher = wrestler.finisher;
+      if (wrestler.weight) item.weight = wrestler.weight;
+      if (wrestler.height) item.height = wrestler.height;
+      if (wrestler.hometown) item.hometown = wrestler.hometown;
+      if (wrestler.alignment) item.alignment = wrestler.alignment;
+      if (wrestler.imageUrl) item.imageUrl = wrestler.imageUrl;
+      if (companyId) item.companyId = companyId;
+
+      validItems.push(item);
+    }
+
+    // Batch write valid items
+    if (validItems.length > 0) {
+      await dynamoDb.batchWrite(TableNames.WRESTLERS, validItems);
+    }
+
+    return created({
+      imported: validItems.length,
+      failed: errors.length,
+      total: wrestlers.length,
+      errors,
+    });
+  } catch (err) {
+    console.error('Failed to import wrestlers:', err);
+    return serverError('Failed to import wrestlers');
+  }
+};

--- a/backend/lib/dynamodb.ts
+++ b/backend/lib/dynamodb.ts
@@ -9,6 +9,7 @@ import {
   ScanCommand,
   QueryCommand,
   TransactWriteCommand,
+  BatchWriteCommand,
   GetCommandInput,
   PutCommandInput,
   UpdateCommandInput,
@@ -70,6 +71,47 @@ export const dynamoDb = {
   transactWrite: async (params: TransactWriteCommandInput) => {
     const command = new TransactWriteCommand(params);
     return docClient.send(command);
+  },
+
+  /**
+   * Writes items in batches of 25 (DynamoDB limit).
+   * Retries unprocessed items up to 3 times with exponential backoff.
+   */
+  batchWrite: async (tableName: string, items: Record<string, unknown>[]): Promise<void> => {
+    const MAX_BATCH_SIZE = 25;
+    const MAX_RETRIES = 3;
+
+    for (let i = 0; i < items.length; i += MAX_BATCH_SIZE) {
+      let writeRequests: { PutRequest?: { Item: Record<string, unknown> } }[] =
+        items.slice(i, i + MAX_BATCH_SIZE).map((item) => ({
+          PutRequest: { Item: item },
+        }));
+
+      for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        const command = new BatchWriteCommand({
+          RequestItems: {
+            [tableName]: writeRequests,
+          },
+        });
+
+        const result = await docClient.send(command);
+        const unprocessed = result.UnprocessedItems?.[tableName];
+
+        if (!unprocessed || unprocessed.length === 0) {
+          break;
+        }
+
+        if (attempt === MAX_RETRIES) {
+          throw new Error(
+            `Failed to write ${unprocessed.length} items after ${MAX_RETRIES} retries`
+          );
+        }
+
+        writeRequests = unprocessed as typeof writeRequests;
+        // Exponential backoff
+        await new Promise((resolve) => setTimeout(resolve, Math.pow(2, attempt) * 100));
+      }
+    }
   },
 
   /**

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -182,14 +182,20 @@ functions:
           cors: *corsConfig
           authorizer: adminAuthorizer
 
-  # Wrestlers (Phase 2 consolidated: getWrestlers, createWrestler, updateWrestler, deleteWrestler)
+  # Wrestlers (Phase 2 consolidated: getWrestlers, createWrestler, updateWrestler, deleteWrestler, importWrestlers)
   wrestlers:
     handler: functions/wrestlers/handler.handler
+    timeout: 30
     events:
       - http:
           path: wrestlers
           method: get
           cors: *corsConfig
+      - http:
+          path: wrestlers/import
+          method: post
+          cors: *corsConfig
+          authorizer: adminAuthorizer
       - http:
           path: wrestlers
           method: post

--- a/docs/plans/plan-issue-5-bulk-import-wrestlers-do.md
+++ b/docs/plans/plan-issue-5-bulk-import-wrestlers-do.md
@@ -1,0 +1,241 @@
+# Plan: Bulk import wrestlers via CSV/JSON upload
+
+**GitHub issue:** #5 — [Bulk import wrestlers via CSV/JSON upload](https://github.com/jpDxsoloOrg/universe_tracker/issues/5)
+
+## Context
+
+Users need to bulk-import many wrestlers at once to quickly populate a new universe. The backend needs a `POST /wrestlers/import` endpoint that accepts an array of wrestler objects, validates each, and uses DynamoDB BatchWriteItem (chunked in batches of 25). The frontend needs a file upload UI with CSV/JSON parsing, preview table, and results summary. Individual wrestler creation remains unchanged.
+
+## Skills to use
+
+| When | Skill | Purpose |
+|------|--------|---------|
+| Before commit | git-commit-helper | Generate conventional commit message |
+
+## Agents and parallel work
+
+- **Suggested order**: Steps 1+2 in parallel → Step 3
+- **Agent types**:
+  - Step 1: `general-purpose` (backend import endpoint + tests)
+  - Step 2: `general-purpose` (frontend import UI + API service + i18n + tests)
+  - Step 3: `general-purpose` (verification and cleanup)
+
+## Implementation steps
+
+### Step 1: Backend import endpoint and tests
+
+**1. Add `batchWrite` utility to `backend/lib/dynamodb.ts`:**
+
+Add a `batchWrite` method to the `dynamoDb` object that wraps `BatchWriteCommand` from `@aws-sdk/lib-dynamodb`. It should accept a table name and an array of items, chunk them into batches of 25, and handle unprocessed items with retry:
+
+```typescript
+batchWrite: async (tableName: string, items: Record<string, unknown>[]) => {
+  const chunks = [];
+  for (let i = 0; i < items.length; i += 25) {
+    chunks.push(items.slice(i, i + 25));
+  }
+  for (const chunk of chunks) {
+    const params = {
+      RequestItems: {
+        [tableName]: chunk.map(item => ({ PutRequest: { Item: item } })),
+      },
+    };
+    let result = await docClient.send(new BatchWriteCommand(params));
+    // Retry unprocessed items (simple retry, not exponential backoff)
+    let retries = 0;
+    while (result.UnprocessedItems && Object.keys(result.UnprocessedItems).length > 0 && retries < 3) {
+      result = await docClient.send(new BatchWriteCommand({ RequestItems: result.UnprocessedItems }));
+      retries++;
+    }
+  }
+}
+```
+
+Import `BatchWriteCommand` from `@aws-sdk/lib-dynamodb` at the top of the file.
+
+**2. Create `backend/functions/wrestlers/importWrestlers.ts`:**
+
+- Parse body expecting `{ wrestlers: WrestlerImport[], companyId?: string }`.
+- `WrestlerImport`: `{ name: string, nickname?: string, finisher?: string, weight?: string, height?: string, hometown?: string, alignment?: 'face' | 'heel' | 'tweener', imageUrl?: string }`.
+- Validate:
+  - `wrestlers` is a non-empty array, max 500 items.
+  - Each entry must have a non-empty `name` (trimmed).
+  - If `alignment` provided, must be one of `face`, `heel`, `tweener`.
+  - Check for duplicate names within the batch (case-insensitive).
+  - If `companyId` provided, verify company exists in COMPANIES table.
+- For each valid wrestler, build a DynamoDB item with: `wrestlerId` (uuid), `name`, optional fields, `companyId` (if provided), `wins: 0`, `losses: 0`, `draws: 0`, `createdAt`, `updatedAt`.
+- Use `dynamoDb.batchWrite(TableNames.WRESTLERS, validItems)` for bulk insert.
+- Return `{ imported: number, failed: number, total: number, errors: Array<{ index: number, name: string, reason: string }> }`.
+- Wrap in try/catch, return serverError on unexpected failure.
+
+**3. Update `backend/functions/wrestlers/handler.ts`:**
+
+Add route: `{ resource: '/wrestlers/import', method: 'POST', handler: importWrestlersHandler }`.
+Import the handler from `./importWrestlers`.
+
+**4. Update `backend/serverless.yml`:**
+
+Add HTTP event to the `wrestlers` function:
+```yaml
+- http:
+    path: wrestlers/import
+    method: post
+    cors: *corsConfig
+    authorizer: adminAuthorizer
+```
+
+Also increase the wrestlers function timeout to 30 seconds (to handle large imports):
+```yaml
+wrestlers:
+  timeout: 30
+```
+
+**5. Create `backend/functions/wrestlers/__tests__/importWrestlers.test.ts`:**
+
+Test cases:
+- Successfully imports array of valid wrestlers, returns 201 with correct counts.
+- Returns 400 when body is null.
+- Returns 400 when wrestlers is not an array.
+- Returns 400 when wrestlers array is empty.
+- Returns 400 when wrestlers array exceeds 500.
+- Returns 400 when a wrestler is missing name.
+- Returns 400 when duplicate names in batch.
+- Returns 400 when invalid alignment value.
+- Validates companyId exists when provided, returns 404 if not found.
+- Handles partial failures (some valid, some invalid entries) — imports valid ones, returns errors for invalid.
+- Handles batch chunking (mock batchWrite to verify it's called).
+- Returns 500 on unexpected error.
+
+Mock `dynamoDb` (get, batchWrite), `uuid`, following the pattern in existing test files like `scheduleMatch.test.ts`.
+
+### Step 2: Frontend import UI, API, i18n, and tests
+
+**1. Add `bulkImport` method to `frontend/src/services/api/wrestlers.api.ts`:**
+
+```typescript
+bulkImport: async (wrestlers: Partial<Wrestler>[], companyId?: string): Promise<BulkImportResponse> => {
+  return fetchWithAuth(`${API_BASE_URL}/wrestlers/import`, {
+    method: 'POST',
+    body: JSON.stringify({ wrestlers, companyId }),
+  });
+}
+```
+
+Add `BulkImportResponse` interface:
+```typescript
+export interface BulkImportResponse {
+  imported: number;
+  failed: number;
+  total: number;
+  errors: Array<{ index: number; name: string; reason: string }>;
+}
+```
+
+**2. Create `frontend/public/templates/wrestler-import-template.csv`:**
+
+```csv
+name,nickname,finisher,weight,height,hometown,alignment
+"Stone Cold Steve Austin","The Rattlesnake","Stone Cold Stunner","252","6'2","Victoria, TX","tweener"
+"The Rock","The Great One","Rock Bottom","260","6'5","Miami, FL","face"
+```
+
+**3. Create `frontend/src/components/admin/ImportWrestlers.tsx`:**
+
+Component structure:
+- **Props**: `onImportComplete: () => void` callback to refresh wrestler list after import.
+- **State**: `file`, `parsedWrestlers`, `validationErrors`, `importing`, `importResult`, `selectedCompanyId`, `companies`.
+- **File upload**: `<input type="file" accept=".csv,.json" />`.
+- **CSV parsing function**: Split by newlines, parse header row, map data rows to wrestler objects. Handle quoted fields with commas inside quotes (simple regex or manual parse).
+- **JSON parsing function**: `JSON.parse(fileContent)` — validate it's an array.
+- **Company selector**: Fetch companies on mount, optional dropdown.
+- **Preview table**: Show parsed wrestlers in a table with columns: #, Name, Nickname, Finisher, Weight, Height, Hometown, Alignment. Highlight rows with validation issues.
+- **Client-side validation**: Check required `name` field, valid `alignment` values, duplicate names.
+- **Import button**: Calls `wrestlersApi.bulkImport(parsedWrestlers, selectedCompanyId)`.
+- **Results panel**: Shows imported/failed counts and error details list.
+- **Template download**: Link to `/templates/wrestler-import-template.csv`.
+- **Clear/Reset button**: Clear file and results to start over.
+
+**4. Create `frontend/src/components/admin/ImportWrestlers.css`:**
+
+Style the import UI following the pattern of ManageCompanies.css — file upload area, preview table, results panel, error list.
+
+**5. Update `frontend/src/components/admin/ManageWrestlers.tsx`:**
+
+Add an "Import Wrestlers" button/section that toggles showing the `ImportWrestlers` component. When import completes, refresh the wrestler list.
+
+**6. Add i18n keys to `frontend/src/i18n/locales/en.json`:**
+
+Under a new `import` section within `wrestlers`:
+```json
+"import": {
+  "title": "Import Wrestlers",
+  "description": "Upload a CSV or JSON file to bulk import wrestlers.",
+  "selectFile": "Select File",
+  "downloadTemplate": "Download CSV Template",
+  "preview": "Preview",
+  "import": "Import",
+  "importing": "Importing...",
+  "results": "Import Results",
+  "imported": "Imported",
+  "failed": "Failed",
+  "total": "Total",
+  "errors": "Errors",
+  "noFile": "No file selected",
+  "invalidFile": "Invalid file type. Please upload a .csv or .json file.",
+  "parseError": "Failed to parse file",
+  "emptyFile": "File contains no wrestler data",
+  "assignToCompany": "Assign to Company (optional)",
+  "noCompany": "No company (global pool)",
+  "clear": "Clear",
+  "csvFormat": "CSV Format",
+  "jsonFormat": "JSON Format"
+}
+```
+
+**7. Add German translations to `frontend/src/i18n/locales/de.json`:**
+
+Same structure with German text.
+
+**8. Create `frontend/src/components/admin/__tests__/ImportWrestlers.test.tsx`:**
+
+Test cases:
+- Renders file upload input and template download link.
+- Parses CSV file and shows preview table.
+- Parses JSON file and shows preview table.
+- Shows validation errors for missing name.
+- Calls API with parsed wrestlers on import button click.
+- Shows import results after successful import.
+- Shows error details for failed imports.
+- Company selector appears and works.
+
+### Step 3: Verification
+
+1. Run `cd backend && npx tsc --project tsconfig.json --noEmit`
+2. Run `cd frontend && npx tsc --project tsconfig.app.json --noEmit`
+3. Run backend tests: `cd backend && npx vitest run`
+4. Run frontend tests: `cd frontend && npx vitest run`
+5. Fix any failures.
+
+## Dependencies and order
+
+- Steps 1 and 2 have no file overlap and can run in parallel.
+- Step 3 depends on Steps 1+2.
+
+**Suggested order:** Steps 1+2 → Step 3
+
+## Testing and verification
+
+- TypeScript compilation passes (both frontend and backend)
+- All existing tests pass
+- New import endpoint returns correct responses for valid/invalid input
+- CSV and JSON parsing works in frontend
+- Preview table displays parsed data correctly
+- Import results show success/failure summary
+- BatchWriteItem handles chunking correctly
+
+## Risks and edge cases
+
+- **Lambda timeout**: Large imports (500 wrestlers) may approach default 6s timeout. Mitigated by setting 30s timeout on wrestlers function.
+- **CSV parsing edge cases**: Quoted fields with commas, newlines in quoted fields, different line endings. Keep CSV parser simple — handle basic quoted commas.
+- **Duplicate detection**: Only checking within batch, not against existing DB records (would require scanning entire table). Can add as future enhancement.
+- **BatchWriteItem unprocessed items**: DynamoDB may return unprocessed items under load. Simple retry logic handles this.

--- a/frontend/public/templates/wrestler-import-template.csv
+++ b/frontend/public/templates/wrestler-import-template.csv
@@ -1,0 +1,4 @@
+name,nickname,finisher,weight,height,hometown,alignment
+"Stone Cold Steve Austin","The Rattlesnake","Stone Cold Stunner","252","6'2","Victoria, TX","tweener"
+"The Rock","The Great One","Rock Bottom","260","6'5","Miami, FL","face"
+"The Undertaker","The Deadman","Tombstone Piledriver","309","6'10","Death Valley","tweener"

--- a/frontend/src/components/admin/ImportWrestlers.css
+++ b/frontend/src/components/admin/ImportWrestlers.css
@@ -1,0 +1,212 @@
+.import-wrestlers {
+  width: 100%;
+}
+
+.import-header {
+  margin-bottom: 1.5rem;
+}
+
+.import-header h3 {
+  margin: 0 0 0.5rem 0;
+  color: #d4af37;
+}
+
+.import-header p {
+  color: #bbb;
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.file-upload-section {
+  background-color: #1a1a1a;
+  border: 2px solid #d4af37;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.file-actions {
+  display: flex;
+  align-items: flex-end;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.file-input-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.file-input-wrapper label {
+  font-size: 0.875rem;
+  color: #ccc;
+}
+
+.template-download-link {
+  color: #d4af37;
+  text-decoration: underline;
+  font-size: 0.875rem;
+  padding-bottom: 0.25rem;
+}
+
+.template-download-link:hover {
+  color: #f0d060;
+}
+
+.company-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.company-selector label {
+  font-size: 0.875rem;
+  color: #ccc;
+}
+
+.company-selector select {
+  width: 100%;
+  max-width: 300px;
+  padding: 0.75rem;
+  background-color: #222;
+  border: 2px solid #444;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 1rem;
+}
+
+.company-selector select:focus {
+  outline: none;
+  border-color: #d4af37;
+}
+
+.preview-section {
+  background-color: #1a1a1a;
+  border: 2px solid #d4af37;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.preview-section h4 {
+  margin: 0 0 1rem 0;
+  color: #d4af37;
+}
+
+.preview-table-wrapper {
+  overflow-x: auto;
+  margin-bottom: 1rem;
+}
+
+.preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.preview-table th,
+.preview-table td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #333;
+}
+
+.preview-table th {
+  color: #d4af37;
+  font-weight: bold;
+  white-space: nowrap;
+}
+
+.preview-table .error-row {
+  background-color: rgba(127, 29, 29, 0.3);
+}
+
+.validation-error {
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+}
+
+.import-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.results-section {
+  background-color: #1a1a1a;
+  border: 2px solid #d4af37;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.results-section h4 {
+  margin: 0 0 1rem 0;
+  color: #d4af37;
+}
+
+.results-summary {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.results-summary span {
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.result-imported {
+  color: #4ade80;
+}
+
+.result-failed {
+  color: #f87171;
+}
+
+.result-total {
+  color: #ccc;
+}
+
+.error-list {
+  margin-top: 1rem;
+}
+
+.error-list h5 {
+  margin: 0 0 0.5rem 0;
+  color: #f87171;
+}
+
+.error-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.error-list li {
+  padding: 0.25rem 0;
+  color: #fca5a5;
+  font-size: 0.875rem;
+}
+
+@media (max-width: 768px) {
+  .file-actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .file-upload-section,
+  .preview-section,
+  .results-section {
+    padding: 1rem;
+  }
+
+  .results-summary {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}

--- a/frontend/src/components/admin/ImportWrestlers.tsx
+++ b/frontend/src/components/admin/ImportWrestlers.tsx
@@ -1,0 +1,345 @@
+import { useState, useEffect, useRef, ChangeEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { wrestlersApi, companiesApi } from '../../services/api';
+import type { BulkImportResponse } from '../../services/api/wrestlers.api';
+import type { Company, Wrestler } from '../../types';
+import './ImportWrestlers.css';
+
+interface ImportWrestlersProps {
+  onImportComplete: () => void;
+}
+
+interface ValidationError {
+  index: number;
+  message: string;
+}
+
+type ParsedWrestler = Partial<Wrestler>;
+
+const VALID_ALIGNMENTS = ['face', 'heel', 'tweener'];
+
+/**
+ * Parse a CSV line handling quoted fields that may contain commas.
+ */
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        // Check for escaped quote ""
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ',') {
+        fields.push(current.trim());
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+  }
+  fields.push(current.trim());
+  return fields;
+}
+
+function parseCsv(text: string): ParsedWrestler[] {
+  const lines = text.split(/\r?\n/).filter(line => line.trim() !== '');
+  if (lines.length < 2) return [];
+
+  const headerLine = lines[0];
+  if (!headerLine) return [];
+  const headers = parseCsvLine(headerLine).map(h => h.trim().toLowerCase());
+
+  return lines.slice(1).map(line => {
+    const values = parseCsvLine(line);
+    const wrestler: Record<string, string> = {};
+    headers.forEach((header, index) => {
+      if (index < values.length && values[index]) {
+        wrestler[header] = values[index];
+      }
+    });
+    return wrestler as ParsedWrestler;
+  });
+}
+
+function validateWrestlers(wrestlers: ParsedWrestler[]): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const namesSeen = new Map<string, number>();
+
+  wrestlers.forEach((wrestler, index) => {
+    if (!wrestler.name || wrestler.name.trim() === '') {
+      errors.push({ index, message: 'wrestlers.import.missingName' });
+    } else {
+      const lowerName = wrestler.name.trim().toLowerCase();
+      const previousIndex = namesSeen.get(lowerName);
+      if (previousIndex !== undefined) {
+        errors.push({ index, message: 'wrestlers.import.duplicateName' });
+      } else {
+        namesSeen.set(lowerName, index);
+      }
+    }
+
+    if (wrestler.alignment && !VALID_ALIGNMENTS.includes(wrestler.alignment)) {
+      errors.push({ index, message: 'wrestlers.import.invalidAlignment' });
+    }
+  });
+
+  return errors;
+}
+
+export default function ImportWrestlers({ onImportComplete }: ImportWrestlersProps) {
+  const { t } = useTranslation();
+  const [parsedWrestlers, setParsedWrestlers] = useState<ParsedWrestler[]>([]);
+  const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
+  const [importing, setImporting] = useState(false);
+  const [importResult, setImportResult] = useState<BulkImportResponse | null>(null);
+  const [selectedCompanyId, setSelectedCompanyId] = useState('');
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    companiesApi.getAll().then(setCompanies).catch(() => {
+      // Companies are optional; ignore errors
+    });
+  }, []);
+
+  const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setError(null);
+    setImportResult(null);
+
+    const extension = file.name.split('.').pop()?.toLowerCase();
+    if (extension !== 'csv' && extension !== 'json') {
+      setError(t('wrestlers.import.invalidFile'));
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const text = event.target?.result as string;
+        let wrestlers: ParsedWrestler[];
+
+        if (extension === 'json') {
+          const parsed: unknown = JSON.parse(text);
+          if (!Array.isArray(parsed)) {
+            setError(t('wrestlers.import.parseError'));
+            return;
+          }
+          wrestlers = parsed as ParsedWrestler[];
+        } else {
+          wrestlers = parseCsv(text);
+        }
+
+        if (wrestlers.length === 0) {
+          setError(t('wrestlers.import.emptyFile'));
+          return;
+        }
+
+        setParsedWrestlers(wrestlers);
+        setValidationErrors(validateWrestlers(wrestlers));
+      } catch (_err) {
+        setError(t('wrestlers.import.parseError'));
+      }
+    };
+    reader.onerror = () => {
+      setError(t('wrestlers.import.parseError'));
+    };
+    reader.readAsText(file);
+  };
+
+  const handleImport = async () => {
+    if (parsedWrestlers.length === 0 || importing) return;
+
+    setImporting(true);
+    setError(null);
+
+    try {
+      const result = await wrestlersApi.bulkImport(
+        parsedWrestlers,
+        selectedCompanyId || undefined,
+      );
+      setImportResult(result);
+      if (result.imported > 0) {
+        onImportComplete();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('wrestlers.import.parseError'));
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const handleClear = () => {
+    setParsedWrestlers([]);
+    setValidationErrors([]);
+    setImportResult(null);
+    setError(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const errorRowIndices = new Set(validationErrors.map(e => e.index));
+  const hasValidationErrors = validationErrors.length > 0;
+
+  return (
+    <div className="import-wrestlers">
+      <div className="import-header">
+        <h3>{t('wrestlers.import.title')}</h3>
+        <p>{t('wrestlers.import.description')}</p>
+      </div>
+
+      {error && <div className="error-message">{error}</div>}
+
+      <div className="file-upload-section">
+        <div className="file-actions">
+          <div className="file-input-wrapper">
+            <label htmlFor="import-file">{t('wrestlers.import.selectFile')}</label>
+            <input
+              type="file"
+              id="import-file"
+              ref={fileInputRef}
+              accept=".csv,.json"
+              onChange={handleFileSelect}
+            />
+          </div>
+          <a
+            href="/templates/wrestler-import-template.csv"
+            download
+            className="template-download-link"
+          >
+            {t('wrestlers.import.downloadTemplate')}
+          </a>
+        </div>
+
+        <div className="company-selector">
+          <label htmlFor="import-company">{t('wrestlers.import.assignToCompany')}</label>
+          <select
+            id="import-company"
+            value={selectedCompanyId}
+            onChange={(e) => setSelectedCompanyId(e.target.value)}
+          >
+            <option value="">{t('wrestlers.import.noCompany')}</option>
+            {companies.map(company => (
+              <option key={company.companyId} value={company.companyId}>
+                {company.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {parsedWrestlers.length > 0 && !importResult && (
+        <div className="preview-section">
+          <h4>{t('wrestlers.import.preview')} ({parsedWrestlers.length})</h4>
+
+          {hasValidationErrors && (
+            <div className="error-message">
+              {validationErrors.map((ve, i) => (
+                <div key={i} className="validation-error">
+                  #{ve.index + 1}: {t(ve.message)}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="preview-table-wrapper">
+            <table className="preview-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Name</th>
+                  <th>Nickname</th>
+                  <th>Finisher</th>
+                  <th>Weight</th>
+                  <th>Height</th>
+                  <th>Hometown</th>
+                  <th>Alignment</th>
+                </tr>
+              </thead>
+              <tbody>
+                {parsedWrestlers.map((wrestler, index) => (
+                  <tr key={index} className={errorRowIndices.has(index) ? 'error-row' : ''}>
+                    <td>{index + 1}</td>
+                    <td>{wrestler.name || ''}</td>
+                    <td>{wrestler.nickname || ''}</td>
+                    <td>{wrestler.finisher || ''}</td>
+                    <td>{wrestler.weight || ''}</td>
+                    <td>{wrestler.height || ''}</td>
+                    <td>{wrestler.hometown || ''}</td>
+                    <td>{wrestler.alignment || ''}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="import-actions">
+            <button
+              onClick={handleImport}
+              disabled={importing || hasValidationErrors}
+            >
+              {importing ? t('wrestlers.import.importing') : t('wrestlers.import.importButton')}
+            </button>
+            <button onClick={handleClear} className="cancel-btn">
+              {t('wrestlers.import.clear')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {importResult && (
+        <div className="results-section">
+          <h4>{t('wrestlers.import.results')}</h4>
+          <div className="results-summary">
+            <span className="result-imported">
+              {t('wrestlers.import.imported')}: {importResult.imported}
+            </span>
+            <span className="result-failed">
+              {t('wrestlers.import.failed')}: {importResult.failed}
+            </span>
+            <span className="result-total">
+              {t('wrestlers.import.total')}: {importResult.total}
+            </span>
+          </div>
+
+          {importResult.errors.length > 0 && (
+            <div className="error-list">
+              <h5>{t('wrestlers.import.errors')}</h5>
+              <ul>
+                {importResult.errors.map((err, i) => (
+                  <li key={i}>
+                    #{err.index + 1} ({err.name}): {err.reason}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="import-actions">
+            <button onClick={handleClear} className="cancel-btn">
+              {t('wrestlers.import.clear')}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/ManageWrestlers.tsx
+++ b/frontend/src/components/admin/ManageWrestlers.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, FormEvent, ChangeEvent } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { wrestlersApi, imagesApi, divisionsApi, companiesApi } from '../../services/api';
 import { sanitizeName } from '../../utils/sanitize';
 import { logger } from '../../utils/logger';
@@ -10,15 +11,18 @@ import {
   resolveImageSrc,
 } from '../../constants/imageFallbacks';
 import type { Wrestler, Division, Company } from '../../types';
+import ImportWrestlers from './ImportWrestlers';
 import './ManageWrestlers.css';
 
 export default function ManageWrestlers() {
+  const { t } = useTranslation();
   const [wrestlers, setWrestlers] = useState<Wrestler[]>([]);
   const [divisions, setDivisions] = useState<Division[]>([]);
   const [companies, setCompanies] = useState<Company[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
+  const [showImport, setShowImport] = useState(false);
   const [editingWrestler, setEditingWrestler] = useState<Wrestler | null>(null);
   const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -253,12 +257,27 @@ export default function ManageWrestlers() {
             details? <Link to="/guide/wiki/admin-manage-wrestlers">Learn more</Link>.
           </p>
         </div>
+        <button
+          onClick={() => setShowImport(!showImport)}
+          className={showImport ? 'cancel-btn' : ''}
+        >
+          {showImport ? t('wrestlers.import.backToList') : t('wrestlers.import.title')}
+        </button>
       </div>
 
       {error && <div className="error-message">{error}</div>}
       {success && <div className="success-message">{success}</div>}
 
-      {showAddForm && (
+      {showImport && (
+        <ImportWrestlers
+          onImportComplete={() => {
+            setShowImport(false);
+            loadData();
+          }}
+        />
+      )}
+
+      {!showImport && showAddForm && (
         <div className="wrestler-form-container">
           <h3>{editingWrestler ? 'Edit Wrestler' : 'Add New Wrestler'}</h3>
           <form onSubmit={handleSubmit} className="wrestler-form">
@@ -346,7 +365,7 @@ export default function ManageWrestlers() {
         </div>
       )}
 
-      <div className="wrestlers-list">
+      {!showImport && <div className="wrestlers-list">
         <h3>All Wrestlers ({wrestlers.length})</h3>
         {wrestlers.length === 0 ? (
           <p>No wrestlers yet. Add your first wrestler!</p>
@@ -405,7 +424,7 @@ export default function ManageWrestlers() {
           </table>
           </div>
         )}
-      </div>
+      </div>}
     </div>
   );
 }

--- a/frontend/src/components/admin/__tests__/ImportWrestlers.test.tsx
+++ b/frontend/src/components/admin/__tests__/ImportWrestlers.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// --- Hoisted mocks ---
+const { mockWrestlersApi, mockCompaniesApi } = vi.hoisted(() => ({
+  mockWrestlersApi: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    bulkImport: vi.fn(),
+  },
+  mockCompaniesApi: {
+    getAll: vi.fn(),
+  },
+}));
+
+vi.mock('../../../services/api', () => ({
+  wrestlersApi: mockWrestlersApi,
+  companiesApi: mockCompaniesApi,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../ImportWrestlers.css', () => ({}));
+
+import ImportWrestlers from '../ImportWrestlers';
+import type { Company } from '../../../types';
+
+const mockCompanies: Company[] = [
+  {
+    companyId: 'comp-1',
+    name: 'WWE',
+    abbreviation: 'WWE',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+  },
+];
+
+const jsonFileContent = JSON.stringify([
+  { name: 'Stone Cold Steve Austin', nickname: 'The Rattlesnake', alignment: 'tweener' },
+  { name: 'The Rock', nickname: 'The Great One', alignment: 'face' },
+]);
+
+function createMockFile(content: string, name: string, type: string): File {
+  return new File([content], name, { type });
+}
+
+describe('ImportWrestlers', () => {
+  const onImportComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCompaniesApi.getAll.mockResolvedValue(mockCompanies);
+  });
+
+  it('renders file upload input and template download link', async () => {
+    render(<ImportWrestlers onImportComplete={onImportComplete} />);
+
+    await waitFor(() => {
+      expect(mockCompaniesApi.getAll).toHaveBeenCalled();
+    });
+
+    expect(screen.getByLabelText('wrestlers.import.selectFile')).toBeInTheDocument();
+    const downloadLink = screen.getByText('wrestlers.import.downloadTemplate');
+    expect(downloadLink.getAttribute('href')).toBe('/templates/wrestler-import-template.csv');
+    expect(downloadLink.getAttribute('download')).toBeDefined();
+  });
+
+  it('calls companiesApi.getAll on mount', () => {
+    render(<ImportWrestlers onImportComplete={onImportComplete} />);
+    expect(mockCompaniesApi.getAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows preview table after selecting a JSON file', async () => {
+    const user = userEvent.setup();
+    render(<ImportWrestlers onImportComplete={onImportComplete} />);
+
+    await waitFor(() => {
+      expect(mockCompaniesApi.getAll).toHaveBeenCalled();
+    });
+
+    const fileInput = screen.getByLabelText('wrestlers.import.selectFile');
+    const file = createMockFile(jsonFileContent, 'wrestlers.json', 'application/json');
+    await user.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(screen.getByText('wrestlers.import.preview (2)')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Stone Cold Steve Austin')).toBeInTheDocument();
+    expect(screen.getByText('The Rock')).toBeInTheDocument();
+    expect(screen.getByText('The Rattlesnake')).toBeInTheDocument();
+    expect(screen.getByText('The Great One')).toBeInTheDocument();
+  });
+
+  it('shows import results after successful import', async () => {
+    const user = userEvent.setup();
+    mockWrestlersApi.bulkImport.mockResolvedValue({
+      imported: 2,
+      failed: 0,
+      total: 2,
+      errors: [],
+    });
+
+    render(<ImportWrestlers onImportComplete={onImportComplete} />);
+
+    await waitFor(() => {
+      expect(mockCompaniesApi.getAll).toHaveBeenCalled();
+    });
+
+    const fileInput = screen.getByLabelText('wrestlers.import.selectFile');
+    const file = createMockFile(jsonFileContent, 'wrestlers.json', 'application/json');
+    await user.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(screen.getByText('wrestlers.import.preview (2)')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'wrestlers.import.importButton' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('wrestlers.import.results')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/wrestlers\.import\.imported.*2/)).toBeTruthy();
+    expect(onImportComplete).toHaveBeenCalled();
+  });
+
+  it('disables import button when no wrestlers are parsed', async () => {
+    render(<ImportWrestlers onImportComplete={onImportComplete} />);
+
+    await waitFor(() => {
+      expect(mockCompaniesApi.getAll).toHaveBeenCalled();
+    });
+
+    // No import button should be visible when no file is loaded
+    expect(screen.queryByRole('button', { name: 'wrestlers.import.importButton' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -693,6 +693,33 @@
       "addMatch": "Kampf hinzufügen"
     }
   },
+  "wrestlers": {
+    "import": {
+      "title": "Wrestler importieren",
+      "description": "Laden Sie eine CSV- oder JSON-Datei hoch, um Wrestler in Massen zu importieren.",
+      "selectFile": "Datei auswählen",
+      "downloadTemplate": "CSV-Vorlage herunterladen",
+      "preview": "Vorschau",
+      "importButton": "Wrestler importieren",
+      "importing": "Importiere...",
+      "results": "Import-Ergebnisse",
+      "imported": "Importiert",
+      "failed": "Fehlgeschlagen",
+      "total": "Gesamt",
+      "errors": "Fehler",
+      "noFile": "Keine Datei ausgewählt",
+      "invalidFile": "Ungültiger Dateityp. Bitte laden Sie eine .csv- oder .json-Datei hoch.",
+      "parseError": "Datei konnte nicht gelesen werden",
+      "emptyFile": "Die Datei enthält keine Wrestler-Daten",
+      "assignToCompany": "Firma zuweisen (optional)",
+      "noCompany": "Keine Firma (globaler Pool)",
+      "clear": "Zurücksetzen",
+      "backToList": "Zurück zur Wrestler-Liste",
+      "missingName": "Name ist erforderlich",
+      "invalidAlignment": "Ungültige Gesinnung (muss Face, Heel oder Tweener sein)",
+      "duplicateName": "Doppelter Name im Import"
+    }
+  },
   "contenders": {
     "title": "Herausforderer-Rangliste",
     "subtitle": "Offizielle Rangliste zur Ermittlung der Meisterschafts-Herausforderer",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -694,6 +694,33 @@
       "addMatch": "Add Match"
     }
   },
+  "wrestlers": {
+    "import": {
+      "title": "Import Wrestlers",
+      "description": "Upload a CSV or JSON file to bulk import wrestlers.",
+      "selectFile": "Select File",
+      "downloadTemplate": "Download CSV Template",
+      "preview": "Preview",
+      "importButton": "Import Wrestlers",
+      "importing": "Importing...",
+      "results": "Import Results",
+      "imported": "Imported",
+      "failed": "Failed",
+      "total": "Total",
+      "errors": "Errors",
+      "noFile": "No file selected",
+      "invalidFile": "Invalid file type. Please upload a .csv or .json file.",
+      "parseError": "Failed to parse file",
+      "emptyFile": "File contains no wrestler data",
+      "assignToCompany": "Assign to Company (optional)",
+      "noCompany": "No company (global pool)",
+      "clear": "Clear",
+      "backToList": "Back to Wrestler List",
+      "missingName": "Name is required",
+      "invalidAlignment": "Invalid alignment (must be face, heel, or tweener)",
+      "duplicateName": "Duplicate name in import"
+    }
+  },
   "contenders": {
     "title": "Contender Rankings",
     "subtitle": "Official rankings determining championship contenders",

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -42,3 +42,4 @@ export type {
   WrestlerMatchStatsResponse,
 } from './statistics.api';
 export type { SeasonAwardsResponse } from './seasonAwards.api';
+export type { BulkImportResponse } from './wrestlers.api';

--- a/frontend/src/services/api/wrestlers.api.ts
+++ b/frontend/src/services/api/wrestlers.api.ts
@@ -1,6 +1,13 @@
 import type { Wrestler } from '../../types';
 import { API_BASE_URL, fetchWithAuth } from './apiClient';
 
+export interface BulkImportResponse {
+  imported: number;
+  failed: number;
+  total: number;
+  errors: Array<{ index: number; name: string; reason: string }>;
+}
+
 export const wrestlersApi = {
   getAll: async (signal?: AbortSignal): Promise<Wrestler[]> => {
     return fetchWithAuth(`${API_BASE_URL}/wrestlers`, {}, signal);
@@ -24,5 +31,12 @@ export const wrestlersApi = {
     return fetchWithAuth(`${API_BASE_URL}/wrestlers/${wrestlerId}`, {
       method: 'DELETE',
     });
+  },
+
+  bulkImport: async (wrestlers: Partial<Wrestler>[], companyId?: string, signal?: AbortSignal): Promise<BulkImportResponse> => {
+    return fetchWithAuth(`${API_BASE_URL}/wrestlers/import`, {
+      method: 'POST',
+      body: JSON.stringify({ wrestlers, ...(companyId ? { companyId } : {}) }),
+    }, signal);
   },
 };


### PR DESCRIPTION
## Summary
- Add `POST /wrestlers/import` endpoint with BatchWriteItem support (chunked in 25-item batches with retry)
- Add `batchWrite` utility to `dynamodb.ts` for reusable bulk write operations
- Frontend `ImportWrestlers` component with CSV/JSON file parsing, preview table, company selector, and results summary
- Integrated into ManageWrestlers admin panel with toggle button
- Downloadable CSV template at `/templates/wrestler-import-template.csv`
- Full i18n support (English + German)

Closes #5.

## Test plan
- [x] Backend TypeScript compiles (59 files, 652 tests pass)
- [x] Frontend TypeScript compiles (47 files, 312 tests pass)
- [ ] Upload CSV file with valid wrestlers — verify all imported
- [ ] Upload JSON file with 30+ wrestlers — verify batch chunking works
- [ ] Test validation: missing name, invalid alignment, duplicate names
- [ ] Test import with company assignment
- [ ] Verify individual wrestler creation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)